### PR TITLE
Remove 'authenticated' requirement for authorization

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -130,7 +130,7 @@
 
         <ul>
           <li><dfn>authentication</dfn> - the process of verifying the identity of an agent executing a request.</li>
-          <li><dfn>authorization</dfn> - the process of determining if an authenticated agent has permission to access a specific resource or perform one of a set of <a>operations</a>.</li>
+          <li><dfn>authorization</dfn> - the process of determining if an agent has permission to access a specific resource or perform one of a set of <a>operations</a>.</li>
           <li><dfn>resource manager</dfn> - (<a href="https://w3c.github.io/lws-ucs/spec/#dfn-controller">controller</a> in UCS) An agent that has permission to control access to a <a>served resource</a>.</li>
         </ul>
 


### PR DESCRIPTION
An agent might be authorized to access a resource without authentication if the resource is public.
While it is true that _usually_ authentication is required for subsequent authorization, it is not _always_ the case.