### PR TITLE
Replace 'absolute URI' with 'URI'

### DIFF
--- a/lws10-core/Authentication.html
+++ b/lws10-core/Authentication.html
@@ -18,9 +18,9 @@
   </p>
 
   <ul>
-    <li><dfn>subject</dfn> <strong>REQUIRED</strong> &mdash; an identifier for an end user. This MUST be an absolute URI.</li>
-    <li><dfn>issuer</dfn> <strong>REQUIRED</strong> &mdash; an identifier for the entity that issued the end-user credential. This MUST be an absolute URI.</li>
-    <li><dfn>client</dfn> <strong>REQUIRED</strong> &mdash; an identifier for a client application. This SHOULD be an absolute URI.</li>
+    <li><dfn>subject</dfn> <strong>REQUIRED</strong> &mdash; an identifier for an end user. This MUST be a URI.</li>
+    <li><dfn>issuer</dfn> <strong>REQUIRED</strong> &mdash; an identifier for the entity that issued the end-user credential. This MUST be a URI.</li>
+    <li><dfn>client</dfn> <strong>REQUIRED</strong> &mdash; an identifier for a client application. This SHOULD be a URI.</li>
     <li><dfn>audience restriction</dfn> <strong>RECOMMENDED</strong> &mdash; a list of values that SHOULD include an authorization server identifier.</li>
   </ul>
 </section>

--- a/lws10-core/Authorization.html
+++ b/lws10-core/Authorization.html
@@ -46,11 +46,11 @@ client (called in this specification <dfn data-cite="RFC6749#section-1.1">author
 
     <ul>
       <li>
-        <strong><code>as_uri</code> REQUIRED</strong> — The value of this parameter is an absolute URI identifying the authorization server
+        <strong><code>as_uri</code> REQUIRED</strong> — The value of this parameter is a URI identifying the authorization server
         where a client can retrieve an access token. The value of this parameter will be the same as the <code>iss</code> claim of a valid access token.
       </li>
       <li>
-        <strong><code>realm</code> REQUIRED</strong> — The value of this parameter is an absolute URI indicating the scope of protection.
+        <strong><code>realm</code> REQUIRED</strong> — The value of this parameter is a URI indicating the scope of protection.
         This value will be included in the audience (<code>aud</code>) claim of an access token. A client MUST verify that
         the URI of the originating request is logically contained within the <code>realm</code> presented in this response.
       </li>
@@ -136,7 +136,7 @@ WWW-Authenticate: Bearer as_uri="https://authorization.example",
       </p>
 
       <ul>
-        <li>The <code>resource</code> parameter is REQUIRED. The value of this parameter MUST be an absolute URI and will be used to populate the
+        <li>The <code>resource</code> parameter is REQUIRED. The value of this parameter MUST be a URI and will be used to populate the
         <code>aud</code> (audience) claim in the resulting access token. The supplied value will be the same as the
         <code>realm</code> parameter response in a <code>WWW-Authenticate</code> challenge. The authorization server
         MUST reject any request in which the resource parameter identifies an unknown or untrusted storage.
@@ -183,16 +183,16 @@ grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange
 
       <ul>
         <li>
-          <code>sub</code> (subject) — <strong>REQUIRED</strong>. This claim MUST be an absolute URI identifying the agent performing the operation
+          <code>sub</code> (subject) — <strong>REQUIRED</strong>. This claim MUST be a URI identifying the agent performing the operation
         </li>
         <li>
-          <code>iss</code> (issuer) — <strong>REQUIRED</strong>. This claim MUST be the absolute URI of the authorization server
+          <code>iss</code> (issuer) — <strong>REQUIRED</strong>. This claim MUST be the URI of the authorization server
         </li>
         <li>
-          <code>client_id</code> (client id) — <strong>REQUIRED</strong>. This claim MUST be an absolute URI identifying the client.
+          <code>client_id</code> (client id) — <strong>REQUIRED</strong>. This claim MUST be a URI identifying the client.
         </li>
         <li>
-          <code>aud</code> (audience) — <strong>REQUIRED</strong>. This claim MUST include the absolute URI supplied by the client
+          <code>aud</code> (audience) — <strong>REQUIRED</strong>. This claim MUST include the URI supplied by the client
           in the resource parameter. This value will be used to restrict the entities for which the access token is valid. This will
           be the same value as provided by a storage server in the <code>realm</code> parameter of a <code>WWW-Authenticate</code> challenge.
         </li>
@@ -306,7 +306,7 @@ Authorization: Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9...
           Issuer Validation: Verify the <code>iss</code> claim matches the expected authorization server identifier.
         </li>
         <li>
-          Audience Validation: Verify the <code>aud</code> claim contains exactly one value and this value is an absolute URI identifying the storage server which logically contains the target resource.
+          Audience Validation: Verify the <code>aud</code> claim contains exactly one value and this value is a URI identifying the storage server which logically contains the target resource.
         </li>
         <li>
           Temporal Validation, subject to an allowable clock skew between systems.


### PR DESCRIPTION
Resolves #46 

The Authentication and Authorization sections of the specification make use of the phrase "absolute URI", but [RFC 3986, section 4.3](https://datatracker.ietf.org/doc/html/rfc3986#section-4.3) defines an absolute URI as a URI without a fragment identifier. It was not the intention of the author to exclude URIs that contain fragment identifiers; instead, the goal was to exclude relative URI references, since these values will generally cross domain and/or security boundaries and so any ambiguity would be problematic. The terminology "URI" implies that these values are not relative URI references.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/pull/48.html" title="Last updated on Dec 18, 2025, 9:11 PM UTC (68fbe6f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/48/d0eb1db...68fbe6f.html" title="Last updated on Dec 18, 2025, 9:11 PM UTC (68fbe6f)">Diff</a>