### PR TITLE
Adjust access token example

### DIFF
--- a/lws10-core/Authorization.html
+++ b/lws10-core/Authorization.html
@@ -285,7 +285,7 @@ signature
       </p>
 
       <pre id="example-authorization-token-presentation" class="example">
-Authorization: Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9...
+Authorization: Bearer eyJ0eXAiOiJhcytqd3QiLCJhbGciOiJFUzI1NiIs...DeWt4QuZXso
       </pre>
     </section>
 


### PR DESCRIPTION
As pointed out in https://github.com/w3c/lws-protocol/pull/45#discussion_r2620170316, the running example of an authorization flow uses different token fragments for each step. For someone who may be trying to follow the flow and who is assuming that each step is part of a single session, it could be confusing to see random token values.

This changes the final token presentation example to use the same token value that is returned from the authorization server in [Example 4](https://w3c.github.io/lws-protocol/lws10-core/#example-authorization-token-exchange-successful-response)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/pull/51.html" title="Last updated on Dec 18, 2025, 10:51 PM UTC (97f5a27)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/51/d0eb1db...97f5a27.html" title="Last updated on Dec 18, 2025, 10:51 PM UTC (97f5a27)">Diff</a>