### PR TITLE
Fix link header example

### DIFF
--- a/lws10-core/Authorization.html
+++ b/lws10-core/Authorization.html
@@ -66,7 +66,7 @@ client (called in this specification <dfn data-cite="RFC6749#section-1.1">author
 
     <pre id="example-unauthorized-response" class="example">
 HTTP/2 401 Unauthorized
-Link: <https://storage.example/storage_1/metadata>; rel="storageDescription"
+Link: &lt;https://storage.example/storage_1/metadata&gt;; rel="storageDescription"
 WWW-Authenticate: Bearer as_uri="https://authorization.example",
                 realm="https://storage.example/storage_1",
                 error="invalid_token"


### PR DESCRIPTION
[Example 1](https://w3c.github.io/lws-protocol/lws10-core/#example-unauthorized-response) in the editor's draft shows an example of a Link header, but the URI reference is not displayed because it is interpreted as an HTML tag. This fixes the rendering so that the value is visible in the example.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/pull/52.html" title="Last updated on Dec 19, 2025, 8:14 PM UTC (8eb8d19)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/52/d0eb1db...8eb8d19.html" title="Last updated on Dec 19, 2025, 8:14 PM UTC (8eb8d19)">Diff</a>