### PR TITLE
Change 'end-user credential' to 'authentication credential'

### DIFF
--- a/lws10-authn-openid/index.html
+++ b/lws10-authn-openid/index.html
@@ -69,16 +69,16 @@
       </p>
 
       <p>
-        The terms "end-user credential" and "authentication suite" are defined by Linked Web Storage Protocol [[!LWS-PROTOCOL]]
+        The terms "authentication credential" and "authentication suite" are defined by Linked Web Storage Protocol [[!LWS-PROTOCOL]]
       </p>
     </section>
 
     <section id="serialization">
-      <h2>End-User Credential Serialization</h2>
+      <h2>Authentication Credential Serialization</h2>
 
       <p>
         OpenID Connect defines a protocol for producing signed ID Tokens, which are used to describe an end-user.
-        An ID Token is serialized as a signed JSON Web Token (JWT). In order to use an ID Token as an LWS end-user credential,
+        An ID Token is serialized as a signed JSON Web Token (JWT). In order to use an ID Token as an LWS authentication credential,
         the following additional requirements apply.
       </p>
 
@@ -107,7 +107,7 @@
       </ul>
 
       <p>
-        An example ID Token that is also an LWS end-user credential is included below.
+        An example ID Token that is also an LWS authentication credential is included below.
       </p>
 
       <pre id="example-id-token" class="example">
@@ -133,22 +133,22 @@ signature
     </section>
 
     <section id="validation">
-      <h2>End-User Credential Validation</h2>
+      <h2>Authentication Credential Validation</h2>
 
       <p>
-        For an ID Token to validate as an LWS end-user credential,
+        For an ID Token to validate as an LWS authentication credential,
         there must be a trust relationship between the verifier and the issuing party.
       </p>
 
       <p>
-        In the absence of a pre-existing trust relationship, the validator MUST dereference the <code>sub</code> (subject) claim in the end-user credential.
+        In the absence of a pre-existing trust relationship, the validator MUST dereference the <code>sub</code> (subject) claim in the authentication credential.
         The resulting resource MUST be formatted as a valid controlled identifier document [[!CID-1.0]] with an <code>id</code> value equal to the subject identifier.
       </p>
 
       <p>
         The verifier MUST use the subject's controlled identifier document to locate a service object whose <code>serviceEndpoint</code> value
-        is equal to the value of the <code>iss</code> claim from the end-user credential, and whose <code>type</code> value is equal to <code>https://www.w3.org/ns/lws#OpenIdProvider</code>.
-        The verifier MUST perform OpenID Connect Discovery to locate the public portion of the JSON Web Key (JWK) used to sign the end-user credential.
+        is equal to the value of the <code>iss</code> claim from the authentication credential, and whose <code>type</code> value is equal to <code>https://www.w3.org/ns/lws#OpenIdProvider</code>.
+        The verifier MUST perform OpenID Connect Discovery to locate the public portion of the JSON Web Key (JWK) used to sign the authentication credential.
         The JWT MUST be validated as described by OpenID Connect Core Section 3.1.3.7 [[!OPENID-CONNECT-CORE]].
       </p>
 
@@ -174,7 +174,7 @@ signature
       <h2>Token Type Identifier</h2>
 
       <p>
-        An ID Token used as an end-user credential MUST use the <code>urn:ietf:params:oauth:token-type:id_token</code> URI when interacting with an authorization server.
+        An ID Token used as an authentication credential MUST use the <code>urn:ietf:params:oauth:token-type:id_token</code> URI when interacting with an authorization server.
       </p>
 
     </section>
@@ -187,9 +187,9 @@ signature
       </p>
 
       <p>
-        An OpenID provider should support a mechanism to restrict the audience of an end-user credential to a limited set of entities, including an authorization server.
+        An OpenID provider should support a mechanism to restrict the audience of an authentication credential to a limited set of entities, including an authorization server.
         One mechanism for achieving this is to use Resource Indicators for OAuth 2.0 [[RFC8707]].
-        A client in possession of an end-user credential with no audience restrictions should exchange this token for an equivalent audience-restricted token by using, for example, OAuth 2.0 Token Exchange [[RFC8693]].
+        A client in possession of an authentication credential with no audience restrictions should exchange this token for an equivalent audience-restricted token by using, for example, OAuth 2.0 Token Exchange [[RFC8693]].
       </p>
 
       <p>
@@ -201,7 +201,7 @@ signature
       </p>
 
       <p>
-        The issuer of an end-user credential is responsible for validating the client identifier.
+        The issuer of an authentication credential is responsible for validating the client identifier.
         The issuer may use mechanisms such as OAuth Client Metadata Document, OAuth 2.0 Client Id Prefix, or OpenID Federation.
       </p>
 

--- a/lws10-authn-saml/index.html
+++ b/lws10-authn-saml/index.html
@@ -55,15 +55,15 @@
       </p>
 
       <p>
-        The terms "end-user credential" and "authentication suite" are defined by Linked Web Storage Protocol [[!LWS-PROTOCOL]]
+        The terms "authentication credential" and "authentication suite" are defined by Linked Web Storage Protocol [[!LWS-PROTOCOL]]
       </p>
     </section>
 
     <section id="serialization">
-      <h2>End-User Credential Serialization</h2>
+      <h2>Authentication Credential Serialization</h2>
 
       <p>
-        SAML tokens used as end-user credentials MUST be signed. In addition, a valid SAML token MUST include the following assertions:
+        SAML tokens used as authentication credentials MUST be signed. In addition, a valid SAML token MUST include the following assertions:
       </p>
 
       <p>
@@ -83,7 +83,7 @@
       </p>
 
       <p>
-        An example SAML End-User Credential is included below.
+        An example SAML Authentication Credential is included below.
       </p>
 
 <pre id="example-saml-token" class="example">
@@ -130,10 +130,10 @@
     </section>
 
     <section id="validation">
-      <h2>End-User Credential Validation</h2>
+      <h2>Authentication Credential Validation</h2>
 
       <p>
-        In order to validate a SAML end-user credential, there must be a trust relationship with the issuing identity provider.
+        In order to validate a SAML authentication credential, there must be a trust relationship with the issuing identity provider.
         This specification does not define how a validating entity establishes a trust relationship with an identity provider,
         expecting these relationships to be established out-of-band.
       </p>
@@ -147,7 +147,7 @@
       <h2>Token Type Identifier</h2>
 
       <p>
-        A SAML 2.0 assertion used as an end-user credential MUST use the <code>urn:ietf:params:oauth:token-type:saml2</code> URI when interacting with an authorization server.
+        A SAML 2.0 assertion used as an authentication credential MUST use the <code>urn:ietf:params:oauth:token-type:saml2</code> URI when interacting with an authorization server.
       </p>
     </section>
 
@@ -159,8 +159,8 @@
       </p>
 
       <p>
-        A SAML identity provider should support a mechanism to restrict the audience of an end-user credential to a limited set of entities,
-        including an authorization server. A client in possession of an end-user credential with no audience restrictions
+        A SAML identity provider should support a mechanism to restrict the audience of an authentication credential to a limited set of entities,
+        including an authorization server. A client in possession of an authentication credential with no audience restrictions
         should exchange this token for an equivalent audience-restricted token by using, for example, OAuth 2.0 Token Exchange [[RFC8693]].
       </p>
     </section>

--- a/lws10-authn-ssi-cid/index.html
+++ b/lws10-authn-ssi-cid/index.html
@@ -38,7 +38,7 @@
       <p>
         Self-issued identity is important for cases where applications act on their own behalf. This includes autonomous bots as well as server-side scripts, among others.
         In these cases, the agent is able to securely manage the private portion of a keypair, which it uses to generate signed JSON Web Tokens (JWT).
-        This specification describes how this class of agents can generate end-user credentials that can be used with a Linked Web Storage.
+        This specification describes how this class of agents can generate authentication credentials that can be used with a Linked Web Storage.
       </p>
     </section>
     <section id="conformance"></section>
@@ -59,15 +59,15 @@
       </p>
 
       <p>
-        The terms "end-user credential" and "authentication suite" are defined by Linked Web Storage Protocol [[!LWS-PROTOCOL]]
+        The terms "authentication credential" and "authentication suite" are defined by Linked Web Storage Protocol [[!LWS-PROTOCOL]]
       </p>
     </section>
 
     <section id="serialization">
-      <h2>End-User Credential Serialization</h2>
+      <h2>Authentication Credential Serialization</h2>
 
       <p>
-        A self-issued end-user credential is serialized as a signed JSON Web Token (JWT). In order to use a JWT as an LWS end-user credential, the following additional requirements apply.
+        A self-issued authentication credential is serialized as a signed JSON Web Token (JWT). In order to use a JWT as an LWS authentication credential, the following additional requirements apply.
       </p>
 
       <p>
@@ -103,10 +103,10 @@
       </p>
 
       <p>
-        An example JWT that is also an LWS end-user credential is included below.
+        An example JWT that is also an LWS authentication credential is included below.
       </p>
 
-      <pre id="example-end-user-token" class="example">
+      <pre id="example-authentication-token" class="example">
 {
   "kid": "c1f52577",
   "kty": "EC",
@@ -129,14 +129,14 @@ signature
     </section>
 
     <section id="validation">
-      <h2>End-User Credential Validation</h2>
+      <h2>Authentication Credential Validation</h2>
 
       <p>
-        In order to validate a JWT as an LWS end-user credential, there must be a trust relationship between the verifier and the issuing party.
+        In order to validate a JWT as an LWS authentication credential, there must be a trust relationship between the verifier and the issuing party.
       </p>
 
       <p>
-        In the absence of a pre-existing trust relationship, the verifier MUST dereference the <code>sub</code> (subject) claim in the end-user credential.
+        In the absence of a pre-existing trust relationship, the verifier MUST dereference the <code>sub</code> (subject) claim in the authentication credential.
         The resulting resource MUST be formatted as a valid controlled identifier document [[!CID-1.0]] with an <code>id</code> value equal to the subject identifier.
       </p>
 
@@ -145,7 +145,7 @@ signature
       </p>
 
       <p>
-        A verifier MUST validate all claims described by the end-user credential data model.
+        A verifier MUST validate all claims described by the authentication credential data model.
       </p>
 
       <p>
@@ -188,7 +188,7 @@ signature
       <h2>Token Type Identifier</h2>
 
       <p>
-        A self-issued JSON Web Token used as an end-user credential MUST use the <code>urn:ietf:params:oauth:token-type:jwt</code> URI when interacting with an authorization server.
+        A self-issued JSON Web Token used as an authentication credential MUST use the <code>urn:ietf:params:oauth:token-type:jwt</code> URI when interacting with an authorization server.
       </p>
 
     </section>

--- a/lws10-authn-ssi-did-key/index.html
+++ b/lws10-authn-ssi-did-key/index.html
@@ -39,7 +39,7 @@
         Self-issued identity is important for cases where applications act on their own behalf.
         This includes autonomous bots as well as server-side scripts, among others.
         In these cases, the agent is able to securely manage the private portion of a keypair, which it uses to generate signed JSON Web Tokens (JWT).
-        This specification describes how this class of agents can generate end-user credentials that can be used with a Linked Web Storage while using agent identifers with the `did:key:` method.
+        This specification describes how this class of agents can generate authentication credentials that can be used with a Linked Web Storage while using agent identifers with the `did:key:` method.
       </p>
     </section>
 
@@ -57,15 +57,15 @@
       </p>
 
       <p>
-        The terms "end-user credential" and "authentication suite" are defined by Linked Web Storage Protocol [[!LWS-PROTOCOL]]
+        The terms "authentication credential" and "authentication suite" are defined by Linked Web Storage Protocol [[!LWS-PROTOCOL]]
       </p>
     </section>
 
     <section id="serialization">
-      <h2>End-User Credential Serialization</h2>
+      <h2>Authentication Credential Serialization</h2>
 
       <p>
-        A self-issued end-user credential is serialized as a signed JSON Web Token (JWT). In order to use a JWT as an LWS end-user credential, the following additional requirements apply.
+        A self-issued authentication credential is serialized as a signed JSON Web Token (JWT). In order to use a JWT as an LWS authentication credential, the following additional requirements apply.
       </p>
 
       <ul>
@@ -103,10 +103,10 @@
       </ul>
 
       <p>
-        An example JWT that is also an LWS end-user credential is included below.
+        An example JWT that is also an LWS authentication credential is included below.
       </p>
 
-      <pre id="example-end-user-token" class="example">
+      <pre id="example-authentication-token" class="example">
 {
   "kty": "EC",
   "alg": "ES256",
@@ -128,14 +128,14 @@ signature
     </section>
 
     <section id="validation">
-      <h2>End-User Credential Validation</h2>
+      <h2>Authentication Credential Validation</h2>
 
       <p>
         For subject identifiers that use the <code>did:key</code> method, a verifier will extract a public key from the identifier itself, as described in Section 3.1.3 of "The did:key Method" [[did-key]]. Using this public key, the signature of the JWT MUST be validated as described in [[!RFC7515]], Section 5.2.
       </p>
 
       <p>
-        A verifier MUST validate all claims described by the end-user credential data model.
+        A verifier MUST validate all claims described by the authentication credential data model.
       </p>
 
       <p>
@@ -147,7 +147,7 @@ signature
       <h2>Token Type Identifier</h2>
 
       <p>
-        A self-issued JSON Web Token used as an end-user credential MUST use the <code>urn:ietf:params:oauth:token-type:jwt</code> URI when interacting with an authorization server.
+        A self-issued JSON Web Token used as an authentication credential MUST use the <code>urn:ietf:params:oauth:token-type:jwt</code> URI when interacting with an authorization server.
       </p>
     </section>
 

--- a/lws10-core/Authentication.html
+++ b/lws10-core/Authentication.html
@@ -1,46 +1,46 @@
 <p>
   This section defines a mechanism for identifying agents and end users that interact
   with a linked web storage server. This specification does not mandate a particular
-  format for end-user credentials, though it does describe how existing identity systems
+  format for authentication credentials, though it does describe how existing identity systems
   can be used in conjunction with the linked web storage authorization framework.
 </p>
 
 <section id="authentication-data-model">
-  <h3>End-User Credential Data Model</h3>
+  <h3>Authentication Credential Data Model</h3>
 
   <p>
     The data model described in this section outlines the requirements for any
-    concrete serialization of an end-user credential.
+    concrete serialization of an authentication credential.
   </p>
 
   <p>
-    An end-user credential MUST include tamper evident claims about a subject, including:
+    An authentication credential MUST include tamper evident claims about a subject, including:
   </p>
 
   <ul>
     <li><dfn>subject</dfn> <strong>REQUIRED</strong> &mdash; an identifier for an end user. This MUST be a URI.</li>
-    <li><dfn>issuer</dfn> <strong>REQUIRED</strong> &mdash; an identifier for the entity that issued the end-user credential. This MUST be a URI.</li>
+    <li><dfn>issuer</dfn> <strong>REQUIRED</strong> &mdash; an identifier for the entity that issued the authentication credential. This MUST be a URI.</li>
     <li><dfn>client</dfn> <strong>REQUIRED</strong> &mdash; an identifier for a client application. This SHOULD be a URI.</li>
     <li><dfn>audience restriction</dfn> <strong>RECOMMENDED</strong> &mdash; a list of values that SHOULD include an authorization server identifier.</li>
   </ul>
 </section>
 
 <section id="authentication-validation">
-  <h3>End-User Credential Validation</h3>
+  <h3>Authentication Credential Validation</h3>
   <p>
-    Validation of an end-user credential requires a trust relationship between the
+    Validation of an authentication credential requires a trust relationship between the
     verifier and issuer of the credential. This trust relationship MAY be established
     through an out-of-band mechanism. Any additional mechanisms for establishing trust
     between a verifier and an issuer are outlined in specific authentication suites.
   </p>
 
   <p>
-    An end-user credential MUST be signed. It is RECOMMENDED that the signature uses asymmetric cryptography.
+    An authentication credential MUST be signed. It is RECOMMENDED that the signature uses asymmetric cryptography.
   </p>
 </section>
 
 <section id="authentication-type-identifier">
-  <h3>End-User Credential Type Identifiers</h3>
+  <h3>Authentication Credential Type Identifiers</h3>
   <p>
     Each authentication suite MUST be associated with a token type URI. An authentication suite SHOULD use a URI defined in the IANA "OAuth URI" registry.
   </p>

--- a/lws10-core/Authorization.html
+++ b/lws10-core/Authorization.html
@@ -119,7 +119,7 @@ WWW-Authenticate: Bearer as_uri="https://authorization.example",
     <p>
       An LWS authorization server is a conforming OAuth 2.0 authorization server, capable of issuing access tokens to a client
       for use with a storage server. In order to issue an access token, a client must first present a valid subject token,
-      such as an end-user credential, to the authorization server via OAuth 2.0 Token Exchange [[!RFC8693]].
+      such as an authentication credential, to the authorization server via OAuth 2.0 Token Exchange [[!RFC8693]].
     </p>
 
     <section id="authorization-token-exchange-request">
@@ -144,7 +144,7 @@ WWW-Authenticate: Bearer as_uri="https://authorization.example",
 
         <li>
           The <code>subject_token</code> parameter is REQUIRED. The value of this parameter MUST include a valid subject token,
-        such as an end-user credential.
+        such as an authentication credential.
         </li>
 
         <li>

--- a/lws10-core/index.html
+++ b/lws10-core/index.html
@@ -163,8 +163,11 @@
         This specificaiton defines the following terms:
       </p>
       <ul>
-        <li><dfn>end-user credential</dfn> &mdash; a security token that asserts claims about an end-user. This token is secured with a cryptographic proof.</li>
-        <li><dfn>authentication suite</dfn> &mdash; a defined validation mechanism for a concrete serialization of an end-user credential.</li>
+        <li><dfn>authentication credential</dfn> &mdash; a security token that asserts claims about an agent or end-user. This token is secured with a cryptographic proof.
+          Examples of an authentication credentials include assertions of identity such as OpenID Connect ID Tokens and SAML-based assertions as well as assertions of
+          capability such as a ZCAP.
+        </li>
+        <li><dfn>authentication suite</dfn> &mdash; a defined validation mechanism for a concrete serialization of an authentication credential.</li>
       </ul>
 
       <p>


### PR DESCRIPTION
As discussed in the [WG meeting of 2026-01-19](https://www.w3.org/2026/01/19-lws-minutes.html#8fee), this changes the terminology of "end-user credential" to "authentication credential". The definition of the term specifically lists examples that include capability credentials in order to be clear that such digital objects are compatible with LWS.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/pull/56.html" title="Last updated on Jan 21, 2026, 9:01 PM UTC (501e6ab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/56/3453fa5...501e6ab.html" title="Last updated on Jan 21, 2026, 9:01 PM UTC (501e6ab)">Diff</a>