### PR TITLE
Clarify storage description URI

### DIFF
--- a/lws10-core/Discovery.html
+++ b/lws10-core/Discovery.html
@@ -68,8 +68,8 @@
     </p>
 
     <p class="note">
-      The URI for a storage description may be distinct from the URI identifying a storage, which may be distinct
-      from the storage's root container. These URIs may also be identical, provided that the resulting representation
+      The URI for a storage description can be distinct from the URI identifying a storage, which can be distinct
+      from the storage's root container. These URIs can also be identical, provided that the resulting representation
       conforms to the requirements outlined in this document.
     </p>
   </section>


### PR DESCRIPTION
Resolves #54

As discussed in the [2026-01-19 WG telecon](https://www.w3.org/2026/01/19-lws-minutes.html#f0b9), this clarifies the expectations for storage identifiers, storage description resources and storage root containers.

Specifically, this removes the `/root` portion of the storage identifier and adds a non-normative note indicating that an implementation may choose to use distinct (or common) URIs to refer to these entitites.

This PR also fixes an inconsistency in whether the `service` field is required. Given that the `service` field is a necessary part of the data binding between storage and storage description, the field cannot be OPTIONAL.

And while the `StorageDescription` service is included in the "minimal example", it is not included in a separate example. This PR also adds the `StorageDescription` service to the more complete example.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/pull/58.html" title="Last updated on Jan 26, 2026, 2:13 PM UTC (1763eea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/58/3453fa5...1763eea.html" title="Last updated on Jan 26, 2026, 2:13 PM UTC (1763eea)">Diff</a>