### PR TITLE
Fix authentication suite titles

### DIFF
--- a/lws10-authn-ssi-cid/index.html
+++ b/lws10-authn-ssi-cid/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>LWS Authentication Suite: OpenID Connect</title>
+    <title>LWS Authentication Suite: Self-signed Identity using Controlled Identifiers</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <link rel="stylesheet" href="local.css"/>
     <script class='remove'>

--- a/lws10-authn-ssi-did-key/index.html
+++ b/lws10-authn-ssi-did-key/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>LWS Authentication Suite: OpenID Connect</title>
+    <title>LWS Authentication Suite: Self-signed Identity using did:key</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <link rel="stylesheet" href="local.css"/>
     <script class='remove'>


### PR DESCRIPTION
As mentioned in https://github.com/w3c/lws-protocol/issues/57#issuecomment-3795306536, some of the authentication suites have incorrect titles.