### PR TITLE
Move Aaron Coburn from editor to author in authN suites

### DIFF
--- a/lws10-authn-openid/index.html
+++ b/lws10-authn-openid/index.html
@@ -12,7 +12,8 @@
         shortName: "lws-authn-openid",
         editors: [{
           name: "Jesse Wright"
-        }, {
+        }],
+        authors: [{
           name: "Aaron Coburn"
         }],
         github: "w3c/lws-protocol",

--- a/lws10-authn-saml/index.html
+++ b/lws10-authn-saml/index.html
@@ -12,7 +12,8 @@
         shortName: "lws-authn-saml",
         editors: [{
           name: "Jesse Wright"
-        }, {
+        }],
+        authors: [{
           name: "Aaron Coburn"
         }],
         github: "w3c/lws-protocol",

--- a/lws10-authn-ssi-cid/index.html
+++ b/lws10-authn-ssi-cid/index.html
@@ -12,7 +12,8 @@
         shortName: "lws-authn-ssi-cid",
         editors: [{
           name: "Jesse Wright"
-        }, {
+        }],
+        authors: [{
           name: "Aaron Coburn"
         }],
         github: "w3c/lws-protocol",

--- a/lws10-authn-ssi-did-key/index.html
+++ b/lws10-authn-ssi-did-key/index.html
@@ -12,7 +12,8 @@
         shortName: "lws-authn-ssi-did-key",
         editors: [{
           name: "Jesse Wright"
-        }, {
+        }],
+        authors: [{
           name: "Aaron Coburn"
         }],
         github: "w3c/lws-protocol",


### PR DESCRIPTION
At present, the various authentication suites list both Jesse Wright and me as editors. It would be more accurate to list Jesse as an editor and me as an author.