### PR TITLE
Add localBiblio reference for the did:key specification

### DIFF
--- a/lws10-authn-ssi-did-key/index.html
+++ b/lws10-authn-ssi-did-key/index.html
@@ -19,6 +19,13 @@
         github: "w3c/lws-protocol",
         xref: ["web-platform"],
         group: "lws",
+        localBiblio: {
+          "did-key": {
+            title: "The did:key Method v0.9",
+            href: "https://w3c-ccg.github.io/did-key-spec/",
+            publisher: "W3C",
+          },
+        },
       };
     </script>
   </head>


### PR DESCRIPTION
The "[LWS Authentication Suite: Self-signed Identity using did:key](https://w3c.github.io/lws-protocol/lws10-authn-ssi-did-key/)" document contains a reference to the `did:key` definition, but specref does not have a reference to it (since it is a community report).

This adds an explicit specification reference via `localBiblio` for the `did:key` method definition.