### PR TITLE
Link auth term instances to their definitions

### DIFF
--- a/lws10-core/Authentication.html
+++ b/lws10-core/Authentication.html
@@ -1,7 +1,7 @@
 <p>
   This section defines a mechanism for identifying agents and end users that interact
   with a linked web storage server. This specification does not mandate a particular
-  format for authentication credentials, though it does describe how existing identity systems
+  format for an <a>authentication credential</a>, though it does describe how existing identity systems
   can be used in conjunction with the linked web storage authorization framework.
 </p>
 
@@ -10,16 +10,16 @@
 
   <p>
     The data model described in this section outlines the requirements for any
-    concrete serialization of an authentication credential.
+    concrete serialization of an <a>authentication credential</a>.
   </p>
 
   <p>
-    An authentication credential MUST include tamper evident claims about a subject, including:
+    An <a>authentication credential</a> MUST include tamper evident claims about a subject, including:
   </p>
 
   <ul>
     <li><dfn>subject</dfn> <strong>REQUIRED</strong> &mdash; an identifier for an end user. This MUST be a URI.</li>
-    <li><dfn>issuer</dfn> <strong>REQUIRED</strong> &mdash; an identifier for the entity that issued the authentication credential. This MUST be a URI.</li>
+    <li><dfn>issuer</dfn> <strong>REQUIRED</strong> &mdash; an identifier for the entity that issued the <a>authentication credential</a>. This MUST be a URI.</li>
     <li><dfn>client</dfn> <strong>REQUIRED</strong> &mdash; an identifier for a client application. This SHOULD be a URI.</li>
     <li><dfn>audience restriction</dfn> <strong>RECOMMENDED</strong> &mdash; a list of values that SHOULD include an authorization server identifier.</li>
   </ul>
@@ -28,21 +28,21 @@
 <section id="authentication-validation">
   <h3>Authentication Credential Validation</h3>
   <p>
-    Validation of an authentication credential requires a trust relationship between the
+    Validation of an <a>authentication credential</a> requires a trust relationship between the
     verifier and issuer of the credential. This trust relationship MAY be established
     through an out-of-band mechanism. Any additional mechanisms for establishing trust
-    between a verifier and an issuer are outlined in specific authentication suites.
+    between a verifier and an issuer are outlined in specific <a data-lt="authentication suite">authentication suites</a>.
   </p>
 
   <p>
-    An authentication credential MUST be signed. It is RECOMMENDED that the signature uses asymmetric cryptography.
+    An <a>authentication credential</a> MUST be signed. It is RECOMMENDED that the signature uses asymmetric cryptography.
   </p>
 </section>
 
 <section id="authentication-type-identifier">
   <h3>Authentication Credential Type Identifiers</h3>
   <p>
-    Each authentication suite MUST be associated with a token type URI. An authentication suite SHOULD use a URI defined in the IANA "OAuth URI" registry.
+    Each <a>authentication suite</a> MUST be associated with a token type URI. An <a>authentication suite</a> SHOULD use a URI defined in the IANA "OAuth URI" registry.
   </p>
 </section>
 

--- a/lws10-core/Authorization.html
+++ b/lws10-core/Authorization.html
@@ -119,7 +119,7 @@ WWW-Authenticate: Bearer as_uri="https://authorization.example",
     <p>
       An LWS authorization server is a conforming OAuth 2.0 authorization server, capable of issuing access tokens to a client
       for use with a storage server. In order to issue an access token, a client must first present a valid subject token,
-      such as an authentication credential, to the authorization server via OAuth 2.0 Token Exchange [[!RFC8693]].
+      such as an <a>authentication credential</a>, to the authorization server via OAuth 2.0 Token Exchange [[!RFC8693]].
     </p>
 
     <section id="authorization-token-exchange-request">
@@ -144,7 +144,7 @@ WWW-Authenticate: Bearer as_uri="https://authorization.example",
 
         <li>
           The <code>subject_token</code> parameter is REQUIRED. The value of this parameter MUST include a valid subject token,
-        such as an authentication credential.
+        such as an <a>authentication credential</a>.
         </li>
 
         <li>


### PR DESCRIPTION
The [editor's draft](https://w3c.github.io/lws-protocol/lws10-core/) of the core LWS specification includes the definition of several terms that are used throughout the document, but these terms are not linked to the associated definition.

This PR ensures that the auth-related terms are linked to their associated definitions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/pull/108.html" title="Last updated on Mar 20, 2026, 4:26 PM UTC (315b234)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/108/4b15391...315b234.html" title="Last updated on Mar 20, 2026, 4:26 PM UTC (315b234)">Diff</a>