### PR TITLE
Review and restructure Access Grant Proposal

### DIFF
--- a/lws10-access-requests/index.html
+++ b/lws10-access-requests/index.html
@@ -34,6 +34,12 @@
             publisher: "W3C",
             status: "REC",
           },
+          "VCARD-RDF": {
+            title: "vCard Ontology - for describing People and Organizations",
+            href: "https://www.w3.org/TR/vcard-rdf/",
+            publisher: "W3C",
+            status: "NOTE",
+          },
         },
       };
     </script>
@@ -569,10 +575,11 @@ lws:Creator a rdfs:Class, skos:Concept ;
         <pre class="example nohighlight" title="JSON-LD context (excerpt)">
 {
   "@context": {
-    "lws":  "https://www.w3.org/ns/lws#",
-    "as":   "https://www.w3.org/ns/activitystreams#",
-    "odrl": "http://www.w3.org/ns/odrl/2/",
-    "xsd":  "http://www.w3.org/2001/XMLSchema#",
+    "lws":   "https://www.w3.org/ns/lws#",
+    "as":    "https://www.w3.org/ns/activitystreams#",
+    "odrl":  "http://www.w3.org/ns/odrl/2/",
+    "vcard": "http://www.w3.org/2006/vcard/ns#",
+    "xsd":   "http://www.w3.org/2001/XMLSchema#",
 
     "AccessRequest":  "lws:AccessRequest",
     "AccessGrant":    "lws:AccessGrant",
@@ -762,10 +769,32 @@ lws:Creator a rdfs:Class, skos:Concept ;
           </p>
 
           <p>
-            The <code>assignee</code> value MAY also reference an ODRL
-            <a href="https://www.w3.org/TR/odrl-model/#party">Party Collection</a>,
-            which represents a group of agents. This allows a single rule to apply to
-            all members of a group.
+            The <code>assignee</code> value MAY also reference a group of agents. A group
+            is represented as a [[!VCARD-RDF|vcard]] <code>Group</code> with one or more
+            <code>hasMember</code> entries identifying the agents in the group. The group
+            definition MAY be provided in several ways:
+          </p>
+
+          <ol>
+            <li>
+              <strong>Inline</strong> &mdash; the group is defined directly within the
+              access request or grant document using a blank node.
+            </li>
+            <li>
+              <strong>Server-hosted</strong> &mdash; the group is defined in a separate
+              resource hosted on the same server, referenced by URI.
+            </li>
+            <li>
+              <strong>External</strong> &mdash; the group is defined at an external URL,
+              referenced by URI.
+            </li>
+          </ol>
+
+          <p>
+            Implementations MAY reject group definitions based on their trust model. For
+            example, a server MAY choose to only accept inline or same-origin group
+            definitions and reject external group URIs. Servers SHOULD document which
+            group definition patterns they support.
           </p>
 
           <p>
@@ -791,7 +820,55 @@ lws:Creator a rdfs:Class, skos:Concept ;
 }
           </pre>
 
-          <pre class="example" title="Assignee as a group (Party Collection)">
+          <pre class="example" title="Inline group definition (blank node)">
+{
+  "permission": [
+    {
+      "action": "read",
+      "target": "https://storage.example/projects/",
+      "assignee": {
+        "type": "vcard:Group",
+        "vcard:hasMember": [
+          { "@id": "https://id.example/alice" },
+          { "@id": "https://id.example/bob" }
+        ]
+      }
+    }
+  ]
+}
+          </pre>
+
+          <pre class="example" title="Server-hosted group (trusted resource on the same server)">
+{
+  "permission": [
+    {
+      "action": "read",
+      "target": "https://storage.example/projects/",
+      "assignee": "https://storage.example/groups/engineering-team"
+    }
+  ]
+}
+          </pre>
+
+          <p>
+            Where the server-hosted resource at
+            <code>https://storage.example/groups/engineering-team</code> contains:
+          </p>
+
+          <pre class="example nohighlight" title="Server-hosted group document">
+{
+  "@context": "https://www.w3.org/ns/lws/v1",
+  "@id": "https://storage.example/groups/engineering-team",
+  "type": "vcard:Group",
+  "vcard:hasMember": [
+    { "@id": "https://id.example/alice" },
+    { "@id": "https://id.example/bob" },
+    { "@id": "https://id.example/carol" }
+  ]
+}
+          </pre>
+
+          <pre class="example" title="External group (hosted at another origin)">
 {
   "permission": [
     {
@@ -802,6 +879,13 @@ lws:Creator a rdfs:Class, skos:Concept ;
   ]
 }
           </pre>
+
+          <p class="note">
+            Accepting an external group URI means the server delegates group membership
+            decisions to the external origin. Implementations should consider the
+            security implications carefully and MAY require explicit authorization
+            before trusting external group definitions.
+          </p>
 
           <pre class="example" title="Public access using foaf:Agent">
 {

--- a/lws10-access-requests/index.html
+++ b/lws10-access-requests/index.html
@@ -28,6 +28,12 @@
             publisher: "W3C",
             status: "ED",
           },
+          "JSON-LD11-FRAMING": {
+            title: "JSON-LD 1.1 Framing",
+            href: "https://www.w3.org/TR/json-ld11-framing/",
+            publisher: "W3C",
+            status: "REC",
+          },
         },
       };
     </script>
@@ -147,9 +153,9 @@
       <p>
         An <a>access request</a> or <a>access grant</a> is a [[!JSON-LD11|JSON-LD]] document with a limited set
         of top-level properties for identity and routing, and an <code>access</code> object that
-        describes the requested or permitted operations. A profile that describes
-        <a>access requests</a> using ODRL
-        concepts is described in <a href="#odrl-access-policy-profile"></a>.
+        describes the requested or permitted operations. The <code>access</code> object is an
+        [[!ODRL-MODEL|ODRL]] Policy, conforming to the profile described in
+        <a href="#odrl-access-policy-profile"></a>.
       </p>
 
       <p>
@@ -166,15 +172,29 @@
   "storage": "https://storage.example/",
   "access": {
     "type": ["ODRLAccessPolicy"],
-    "action": ["read", "create"],
-    "assignee": "https://id.example/agent",
-    "target": ["https://storage.example/projects/"],
-    "hasPurpose": ["https://purpose.example/collaboration"],
-    "constraint": [
+    "profile": "https://www.w3.org/ns/lws#ODRLAccessProfile",
+    "permission": [
       {
-        "leftOperand": "dateTime",
-        "operator": "lteq",
-        "rightOperand": "2026-06-09T10:00:00Z"
+        "action": "read",
+        "target": "https://storage.example/projects/",
+        "assignee": "https://id.example/agent",
+        "constraint": [
+          {
+            "leftOperand": "dateTime",
+            "operator": "lteq",
+            "rightOperand": "2026-06-09T10:00:00Z"
+          },
+          {
+            "leftOperand": "purpose",
+            "operator": "eq",
+            "rightOperand": "https://purpose.example/collaboration"
+          }
+        ]
+      },
+      {
+        "action": "create",
+        "target": "https://storage.example/projects/",
+        "assignee": "https://id.example/agent"
       }
     ]
   }
@@ -194,15 +214,20 @@
   "storage": "https://storage.example/",
   "access": {
     "type": ["ODRLAccessPolicy"],
-    "action": ["read"],
-    "assignee": "https://id.example/agent",
-    "target": ["https://storage.example/projects/"],
-    "hasPurpose": ["https://purpose.example/collaboration"],
-    "constraint": [
+    "uid": "urn:uuid:e6a09a85-3f72-4e6d-bcd3-7e4a0e6378a2",
+    "profile": "https://www.w3.org/ns/lws#ODRLAccessProfile",
+    "permission": [
       {
-        "leftOperand": "dateTime",
-        "operator": "lteq",
-        "rightOperand": "2026-06-09T10:00:00Z"
+        "action": "read",
+        "target": "https://storage.example/projects/",
+        "assignee": "https://id.example/agent",
+        "constraint": [
+          {
+            "leftOperand": "dateTime",
+            "operator": "lteq",
+            "rightOperand": "2026-06-09T10:00:00Z"
+          }
+        ]
       }
     ]
   }
@@ -353,238 +378,435 @@
       <p>
         This specification defines an Access Policy profile based on the
         [[!ODRL-MODEL|ODRL Information Model]] and [[!ODRL-VOCAB|ODRL Vocabulary]], identified
-        with the URL:
+        by the URL:
         <code>https://www.w3.org/ns/lws#ODRLAccessProfile</code>.
       </p>
 
       <p>
-        Servers that support this profile MUST validate the following properties on the
-        <code>access</code> object of an <a>access request</a> and <a>access grant</a>.
+        The <code>access</code> object of an <a>access request</a> or <a>access grant</a>
+        conforming to this profile is an ODRL
+        <a href="https://www.w3.org/TR/odrl-model/#policy-set">Policy</a> containing one or more
+        rules. Each rule is a
+        <a href="https://www.w3.org/TR/odrl-model/#permission">Permission</a>,
+        <a href="https://www.w3.org/TR/odrl-model/#prohibition">Prohibition</a>, or
+        <a href="https://www.w3.org/TR/odrl-model/#obligation">Obligation</a>.
+        Each rule carries its own <code>action</code>, <code>target</code>,
+        <code>assignee</code>, and <code>constraint</code> properties.
       </p>
 
-      <section id="odrl-type">
-        <h3>Types</h3>
+      <section id="profile-vocabulary">
+        <h3>Vocabulary</h3>
 
         <p>
-          The <code>type</code> property expresses the type of access policy.
+          This profile introduces the following terms, defined in the
+          <code>https://www.w3.org/ns/lws#</code> namespace. Terms that already exist in
+          the [[!ODRL-VOCAB|ODRL Vocabulary]] (<code>read</code>, <code>modify</code>,
+          <code>delete</code>, <code>dateTime</code>, <code>purpose</code>) are reused
+          directly.
+        </p>
+
+        <section id="vocab-actions">
+          <h4>Actions</h4>
+
+          <p>
+            The <code>action</code> property on a rule describes the operation that the agent
+            wishes to perform (in the case of a request) or is authorized to perform (in the
+            case of a grant). The value of the <code>action</code> property MUST be a string
+            corresponding to an action recognized by the server.
+          </p>
+
+          <p>
+            The following action values MUST be supported by servers advertising this profile:
+          </p>
+
+          <ul>
+            <li><code>read</code> &mdash; retrieve a resource or its metadata (HTTP GET, HEAD).
+              Defined by [[!ODRL-VOCAB]].</li>
+            <li><code>modify</code> &mdash; modify an existing resource (HTTP PUT, PATCH).
+              Defined by [[!ODRL-VOCAB]].</li>
+            <li><code>append</code> &mdash; add content to an existing resource without removing
+              or replacing existing content (HTTP PATCH, insert-only). Defined by this
+              specification as
+              <a href="https://www.w3.org/TR/odrl-vocab/#term-includedIn">included in</a>
+              <code>modify</code>; granting <code>modify</code> implicitly includes
+              <code>append</code>, but granting <code>append</code> alone does not permit
+              full modification.</li>
+            <li><code>create</code> &mdash; create a new resource within a container
+              (HTTP POST). Defined by this specification.</li>
+            <li><code>delete</code> &mdash; remove an existing resource (HTTP DELETE).
+              Defined by [[!ODRL-VOCAB]].</li>
+          </ul>
+
+          <p>
+            The formal RDF definitions for the profile-specific actions are:
+          </p>
+
+          <pre class="example nohighlight" title="LWS ODRL Profile actions (Turtle)">
+@prefix lws:  &lt;https://www.w3.org/ns/lws#&gt; .
+@prefix odrl: &lt;http://www.w3.org/ns/odrl/2/&gt; .
+@prefix rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt; .
+@prefix skos: &lt;http://www.w3.org/2004/02/skos/core#&gt; .
+
+lws:create a odrl:Action, skos:Concept ;
+    rdfs:label "Create"@en ;
+    skos:definition "Create a new resource within a container."@en ;
+    odrl:includedIn odrl:use ;
+    skos:note "Corresponds to HTTP POST on an LWS container."@en .
+
+lws:append a odrl:Action, skos:Concept ;
+    rdfs:label "Append"@en ;
+    skos:definition "Add content to an existing resource without removing or replacing existing content."@en ;
+    odrl:includedIn odrl:modify ;
+    skos:note "Corresponds to an insert-only HTTP PATCH on an LWS resource."@en .
+          </pre>
+        </section>
+
+        <section id="vocab-left-operands">
+          <h4>Left Operands</h4>
+
+          <p>
+            The following left operand values are used in
+            <a href="https://www.w3.org/TR/odrl-model/#constraint-class">Constraint</a>
+            objects. A server advertising support for this profile MUST support all of
+            these values:
+          </p>
+
+          <ul>
+            <li><code>dateTime</code> &mdash; the current date and time. Defined by
+              [[!ODRL-VOCAB]].</li>
+            <li><code>purpose</code> &mdash; the intended purpose of the access. Defined by
+              [[!ODRL-VOCAB]].</li>
+            <li><code>client</code> &mdash; the client identifier for an HTTP request.
+              Defined by this specification.</li>
+            <li><code>mediaType</code> &mdash; the media type of the target HTTP resource.
+              Defined by this specification.</li>
+            <li><code>type</code> &mdash; the type URL expressed in a resource's link headers.
+              Defined by this specification.</li>
+          </ul>
+
+          <p>
+            The formal RDF definitions for the profile-specific left operands are:
+          </p>
+
+          <pre class="example nohighlight" title="LWS ODRL Profile left operands (Turtle)">
+@prefix lws:  &lt;https://www.w3.org/ns/lws#&gt; .
+@prefix odrl: &lt;http://www.w3.org/ns/odrl/2/&gt; .
+@prefix rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt; .
+@prefix skos: &lt;http://www.w3.org/2004/02/skos/core#&gt; .
+
+lws:client a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "Client"@en ;
+    skos:definition "The client identifier for an HTTP request."@en ;
+    skos:note "Used to restrict access to specific client applications."@en .
+
+lws:mediaType a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "Media Type"@en ;
+    skos:definition "The media type of the target HTTP resource."@en ;
+    skos:note "Used to restrict access based on IANA media types."@en .
+
+lws:type a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "Resource Type"@en ;
+    skos:definition "The type URL expressed in a resource's link headers."@en ;
+    skos:note "Used to restrict access based on Link rel=type headers."@en .
+          </pre>
+        </section>
+      </section>
+
+      <section id="profile-jsonld-context">
+        <h3>JSON-LD Context</h3>
+
+        <p>
+          The LWS JSON-LD context (<code>https://www.w3.org/ns/lws/v1</code>) maps the
+          short-form property names used in this specification to their full IRIs. This
+          context MUST be included in the <code>@context</code> of any <a>access request</a>
+          or <a>access grant</a> conforming to this profile.
         </p>
 
         <p>
-          The value of the <code>type</code> property MUST be an array of strings that includes
-          <code>ODRLAccessPolicy</code>. Additional type values MAY be included.
+          The following excerpt shows the context entries relevant to this profile:
         </p>
 
-        <p>
-          The property is REQUIRED.
-        </p>
-
-        <pre class="example" title="ODRL access policy type">
+        <pre class="example nohighlight" title="JSON-LD context (excerpt)">
 {
-  "access": {
-    "type": ["ODRLAccessPolicy"]
+  "@context": {
+    "lws":  "https://www.w3.org/ns/lws#",
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "xsd":  "http://www.w3.org/2001/XMLSchema#",
+
+    "AccessRequest":     "lws:AccessRequest",
+    "AccessGrant":       "lws:AccessGrant",
+    "ODRLAccessPolicy":  "lws:ODRLAccessPolicy",
+
+    "access":      "lws:access",
+    "profile":     "odrl:profile",
+    "uid":         "odrl:uid",
+    "permission":  { "@id": "odrl:permission",  "@container": "@set" },
+    "prohibition": { "@id": "odrl:prohibition", "@container": "@set" },
+    "obligation":  { "@id": "odrl:obligation",  "@container": "@set" },
+
+    "action":       "odrl:action",
+    "target":       { "@id": "odrl:target",   "@type": "@id" },
+    "assignee":     { "@id": "odrl:assignee", "@type": "@id" },
+    "constraint":   { "@id": "odrl:constraint",    "@container": "@set" },
+    "leftOperand":  "odrl:leftOperand",
+    "operator":     "odrl:operator",
+    "rightOperand": "odrl:rightOperand",
+
+    "read":      "odrl:read",
+    "modify":    "odrl:modify",
+    "delete":    "odrl:delete",
+    "create":    "lws:create",
+    "append":    "lws:append",
+    "dateTime":  "odrl:dateTime",
+    "purpose":   "odrl:purpose",
+    "client":    "lws:client",
+    "mediaType": "lws:mediaType",
+    "type":      "lws:type",
+
+    "eq":       "odrl:eq",
+    "lt":       "odrl:lt",
+    "lteq":     "odrl:lteq",
+    "gteq":     "odrl:gteq",
+    "isAnyOf":  "odrl:isAnyOf"
   }
 }
         </pre>
       </section>
 
-      <section id="odrl-action">
-        <h3>Actions</h3>
+      <section id="profile-jsonld-frame">
+        <h3>JSON-LD Frame</h3>
 
         <p>
-          The <code>action</code> property describes the operations that the agent wishes to
-          perform (in the case of a request) or is authorized to perform (in the case of a grant).
+          A [[!JSON-LD11-FRAMING|JSON-LD Frame]] can be used to ensure a deterministic
+          shape when deserializing an <a>access request</a> or <a>access grant</a>. The
+          following frame produces the structure used in this specification:
         </p>
 
-        <p>
-          The value of the <code>action</code> property MUST be a non-empty array of strings.
-          Each value MUST correspond to an operation recognized by the server. The following
-          values MUST be supported: <code>read</code>, <code>modify</code>, <code>append</code>,
-          <code>create</code>, and <code>delete</code>. The <code>read</code>,
-          <code>modify</code>, and <code>delete</code> values are defined by the
-          [[!ODRL-VOCAB|ODRL Vocabulary]]. The <code>create</code> and <code>append</code>
-          values are defined by this specification.
-        </p>
+        <pre class="example nohighlight" title="JSON-LD frame for access documents">
+{
+  "@context": "https://www.w3.org/ns/lws/v1",
+  "type": {},
+  "access": {
+    "type": "ODRLAccessPolicy",
+    "permission": {
+      "action": {},
+      "target": {},
+      "assignee": {},
+      "constraint": {}
+    },
+    "prohibition": {
+      "action": {},
+      "target": {},
+      "assignee": {},
+      "constraint": {}
+    },
+    "obligation": {
+      "action": {},
+      "target": {},
+      "assignee": {},
+      "constraint": {}
+    }
+  }
+}
+        </pre>
+      </section>
+
+      <section id="profile-policy">
+        <h3>Policy</h3>
 
         <p>
-          The <code>append</code> action is defined as
-          <a href="https://www.w3.org/TR/odrl-vocab/#term-includedIn">included in</a>
-          <code>modify</code>. This means that granting <code>modify</code> implicitly
-          includes <code>append</code>, but granting <code>append</code> alone does not
-          permit full modification of a resource.
-        </p>
-
-        <p>
-          These action values correspond to LWS operations as follows:
+          The <code>access</code> object MUST be a valid ODRL Policy. The following
+          properties are defined on the Policy:
         </p>
 
         <ul>
-          <li><code>read</code> &mdash; retrieve a resource or its metadata (HTTP GET, HEAD)</li>
-          <li><code>modify</code> &mdash; modify an existing resource (HTTP PUT, PATCH)</li>
           <li>
-            <code>append</code> &mdash; add content to an existing resource without removing
-            or replacing existing content (HTTP PATCH, insert-only)
+            <code>type</code> &mdash; REQUIRED. MUST be an array of strings that includes
+            <code>ODRLAccessPolicy</code>. Additional type values MAY be included.
           </li>
           <li>
-            <code>create</code> &mdash; create a new resource within a container (HTTP POST)
+            <code>profile</code> &mdash; REQUIRED. MUST be the string
+            <code>https://www.w3.org/ns/lws#ODRLAccessProfile</code>.
           </li>
-          <li><code>delete</code> &mdash; remove an existing resource (HTTP DELETE)</li>
+          <li>
+            <code>uid</code> &mdash; OPTIONAL. A URI that uniquely identifies the policy.
+            Servers SHOULD assign a <code>uid</code> when creating an <a>access grant</a>.
+          </li>
+          <li>
+            <code>permission</code> &mdash; an array of Permission rules.
+          </li>
+          <li>
+            <code>prohibition</code> &mdash; an array of Prohibition rules.
+          </li>
+          <li>
+            <code>obligation</code> &mdash; an array of Obligation (Duty) rules.
+          </li>
         </ul>
 
         <p>
-          This property is REQUIRED.
+          At least one of <code>permission</code>, <code>prohibition</code>, or
+          <code>obligation</code> MUST be present.
         </p>
 
-        <pre class="example" title="action property">
+        <pre class="example" title="ODRL Access Policy">
 {
   "access": {
-    "action": ["read", "create"]
-  }
-}
-        </pre>
-      </section>
-
-      <section id="odrl-assignee">
-        <h3>Assignee</h3>
-
-        <p>
-          The <code>assignee</code> property identifies the party that is requesting access (in
-          the case of a request) or that is being granted access (in the case of a grant).
-        </p>
-
-        <p>
-          The value of the <code>assignee</code> property MUST be a URI. Public access MAY be
-          assigned using the <code>Agent</code> class from the [[!FOAF|FOAF vocabulary]], identified by the URI
-          <code>http://xmlns.com/foaf/0.1/Agent</code>.
-        </p>
-
-        <p>
-          This property is REQUIRED.
-        </p>
-
-        <pre class="example" title="assignee property">
-{
-  "access": {
-    "assignee": "https://id.example/agent"
-  }
-}
-        </pre>
-      </section>
-
-      <section id="odrl-target">
-        <h3>Targets</h3>
-
-        <p>
-          The <code>target</code> property identifies the resources to which the
-          <a>access request</a> or <a>access grant</a> applies.
-        </p>
-
-        <p>
-          The <code>target</code> property MUST be a non-empty array of resource identifiers.
-          When a URI is provided that identifies a container, the access applies to all resources
-          that are members of that container or any subcontainers.
-        </p>
-
-        <p>
-          This property is OPTIONAL.
-        </p>
-
-        <pre class="example" title="target property">
-{
-  "access": {
-    "target": [
-      "https://storage.example/projects/alpha",
-      "https://storage.example/projects/beta"
+    "type": ["ODRLAccessPolicy"],
+    "profile": "https://www.w3.org/ns/lws#ODRLAccessProfile",
+    "permission": [
+      {
+        "action": "read",
+        "target": "https://storage.example/projects/",
+        "assignee": "https://id.example/agent"
+      }
     ]
   }
 }
         </pre>
       </section>
 
-      <section id="odrl-hasPurpose">
-        <h3>Purposes</h3>
+      <section id="profile-rules">
+        <h3>Rules</h3>
 
         <p>
-          The <code>hasPurpose</code> property describes the intended use of the access being
-          requested or granted.
+          Each rule within a Policy is a Permission, Prohibition, or Obligation object.
+          Rules have the following properties:
         </p>
 
-        <p>
-          The value of the <code>hasPurpose</code> property MUST be an array. Each element MUST
-          be a URI identifying a purpose.
-        </p>
+        <section id="rule-action">
+          <h4>Action</h4>
 
-        <p>
-          This property is OPTIONAL.
-        </p>
+          <p>
+            The <code>action</code> property identifies the operation for the rule. The value
+            MUST be a string corresponding to a supported action (see
+            <a href="#vocab-actions"></a>).
+          </p>
 
-        <pre class="example" title="hasPurpose property">
+          <p>
+            This property is REQUIRED.
+          </p>
+
+          <pre class="example" title="Rule with action">
 {
-  "access": {
-    "hasPurpose": ["https://purpose.example/collaboration"]
-  }
+  "permission": [
+    {
+      "action": "read"
+    }
+  ]
 }
-        </pre>
+          </pre>
+        </section>
+
+        <section id="rule-assignee">
+          <h4>Assignee</h4>
+
+          <p>
+            The <code>assignee</code> property identifies the party that is requesting
+            access (in the case of a request) or that is being granted access (in the case
+            of a grant).
+          </p>
+
+          <p>
+            The value of the <code>assignee</code> property MUST be a URI. Public access
+            MAY be assigned using the <code>Agent</code> class from the
+            [[!FOAF|FOAF vocabulary]], identified by the URI
+            <code>http://xmlns.com/foaf/0.1/Agent</code>.
+          </p>
+
+          <p>
+            This property is REQUIRED.
+          </p>
+
+          <pre class="example" title="Rule with assignee">
+{
+  "permission": [
+    {
+      "action": "read",
+      "assignee": "https://id.example/agent"
+    }
+  ]
+}
+          </pre>
+        </section>
+
+        <section id="rule-target">
+          <h4>Target</h4>
+
+          <p>
+            The <code>target</code> property identifies the resource to which the rule
+            applies.
+          </p>
+
+          <p>
+            The value of the <code>target</code> property MUST be a URI identifying a
+            resource. When the URI identifies a container, the rule applies to all resources
+            that are members of that container or any subcontainers.
+          </p>
+
+          <p>
+            This property is OPTIONAL, though servers MAY require it.
+          </p>
+
+          <pre class="example" title="Rule with target">
+{
+  "permission": [
+    {
+      "action": "read",
+      "target": "https://storage.example/projects/",
+      "assignee": "https://id.example/agent"
+    }
+  ]
+}
+          </pre>
+        </section>
+
+        <section id="rule-constraint">
+          <h4>Constraints</h4>
+
+          <p>
+            The <code>constraint</code> property defines conditions that limit or qualify the
+            rule. This property uses the ODRL
+            <a href="https://www.w3.org/TR/odrl-model/#constraint-class">Constraint</a>
+            model.
+          </p>
+
+          <p>
+            The value of the <code>constraint</code> property MUST be an array of constraint
+            objects. Each constraint object MUST include the following properties:
+          </p>
+
+          <ul>
+            <li>
+              <code>leftOperand</code> &mdash; a string identifying the operand being
+              constrained (see <a href="#vocab-left-operands"></a>).
+            </li>
+            <li>
+              <code>operator</code> &mdash; a string identifying the comparison operator.
+              Supported values include: <code>eq</code>, <code>lt</code>, <code>lteq</code>,
+              <code>gteq</code>, and <code>isAnyOf</code>.
+            </li>
+            <li>
+              <code>rightOperand</code> &mdash; the value to compare against. The type
+              depends on the <code>leftOperand</code>.
+            </li>
+          </ul>
+
+          <p>
+            When multiple constraint objects are present on a rule, all of them MUST be
+            satisfied.
+          </p>
+
+          <p>
+            This property is OPTIONAL.
+          </p>
+        </section>
       </section>
 
-      <section id="odrl-constraint">
-        <h3>Constraints</h3>
+      <section id="constraint-examples">
+        <h3>Constraint Examples</h3>
 
         <p>
-          The <code>constraint</code> property defines conditions that limit or qualify the
-          access being requested or granted. This property uses the ODRL
-          <a href="https://www.w3.org/TR/odrl-model/#constraint-class">Constraint</a> model.
-        </p>
-
-        <p>
-          The value of the <code>constraint</code> property MUST be an array of constraint
-          objects. Each constraint object MUST include the following properties:
-        </p>
-
-        <ul>
-          <li>
-            <code>leftOperand</code> &mdash; a string identifying the operand being constrained.
-          </li>
-          <li>
-            <code>operator</code> &mdash; a string identifying the comparison operator.
-          </li>
-          <li>
-            <code>rightOperand</code> &mdash; the value to compare against. The type depends on
-            the <code>leftOperand</code>.
-          </li>
-        </ul>
-
-        <p>
-          When multiple constraint objects are present, all of them MUST be satisfied.
-        </p>
-
-        <p>
-          A server advertising support for this profile MUST support the following
-          <code>leftOperand</code> values:
-        </p>
-
-        <ul>
-          <li>
-            <code>client</code> &mdash; representing the client identifier for an HTTP request
-          </li>
-          <li>
-            <code>mediaType</code> &mdash; representing the media type of the target HTTP
-            resource
-          </li>
-          <li>
-            <code>type</code> &mdash; representing the type URL expressed in a resource's link
-            headers
-          </li>
-          <li>
-            <code>dateTime</code> &mdash; representing the current date time
-          </li>
-        </ul>
-
-        <p>
-          This property is OPTIONAL.
-        </p>
-
-        <p>
-          The following examples illustrate the use of these constraints:
+          The following examples illustrate the use of constraints within rules.
         </p>
 
         <section id="constraint-client">
@@ -592,22 +814,27 @@
 
           <p>
             The following example uses a <code>leftOperand</code> value of
-            <code>client</code> to restrict access
-            to a specific client application. When the <code>eq</code> operator is used, the
-            <code>rightOperand</code> value is a URI identifying the client:
+            <code>client</code> to restrict a permission to a specific client application.
+            When the <code>eq</code> operator is used, the <code>rightOperand</code> value
+            is a URI identifying the client:
           </p>
 
           <pre class="example" title="Client constraint">
 {
-  "access": {
-    "constraint": [
-      {
-        "leftOperand": "client",
-        "operator": "eq",
-        "rightOperand": "https://app.example/client-id"
-      }
-    ]
-  }
+  "permission": [
+    {
+      "action": "read",
+      "target": "https://storage.example/projects/",
+      "assignee": "https://id.example/agent",
+      "constraint": [
+        {
+          "leftOperand": "client",
+          "operator": "eq",
+          "rightOperand": "https://app.example/client-id"
+        }
+      ]
+    }
+  ]
 }
           </pre>
         </section>
@@ -617,26 +844,28 @@
 
           <p>
             The following example uses a <code>leftOperand</code> value of
-            <code>mediaType</code> to restrict
-            access to resources with specific media types. When the <code>eq</code> operator
-            is used, the <code>rightOperand</code> value is a string identifying an
-            <a href="https://www.iana.org/assignments/media-types/">IANA media type</a>. When
-            the <code>isAnyOf</code> operator is used, the <code>rightOperand</code> value
-            is an array of media type strings, and access is permitted if the resource's
-            media type matches any of the listed values:
+            <code>mediaType</code> to restrict a permission to resources with specific media
+            types. When the <code>isAnyOf</code> operator is used, the
+            <code>rightOperand</code> value is an array of media type strings, and access
+            is permitted if the resource's media type matches any of the listed values:
           </p>
 
           <pre class="example" title="Media type constraint">
 {
-  "access": {
-    "constraint": [
-      {
-        "leftOperand": "mediaType",
-        "operator": "isAnyOf",
-        "rightOperand": ["image/jpeg", "image/png"]
-      }
-    ]
-  }
+  "permission": [
+    {
+      "action": "read",
+      "target": "https://storage.example/media/",
+      "assignee": "https://id.example/agent",
+      "constraint": [
+        {
+          "leftOperand": "mediaType",
+          "operator": "isAnyOf",
+          "rightOperand": ["image/jpeg", "image/png"]
+        }
+      ]
+    }
+  ]
 }
           </pre>
         </section>
@@ -657,26 +886,59 @@ Link: &lt;https://type.example/Playlist&gt;; rel="type"
             The following example uses a <code>leftOperand</code> value of
             <code>type</code> to restrict access based on the resource types advertised
             in HTTP <code>Link</code> headers.
-            When the <code>eq</code> operator is used, the <code>rightOperand</code> value
-            is a URI identifying a resource type. When the <code>isAnyOf</code> operator is
-            used, the <code>rightOperand</code> value is an array of type URIs, and access
-            is permitted if the resource's type matches any of the listed values:
+            When the <code>isAnyOf</code> operator is used, the <code>rightOperand</code>
+            value is an array of type URIs, and access is permitted if the resource's type
+            matches any of the listed values:
           </p>
 
           <pre class="example" title="Resource type constraint">
 {
-  "access": {
-    "constraint": [
-      {
-        "leftOperand": "type",
-        "operator": "isAnyOf",
-        "rightOperand": [
-          "https://type.example/Playlist",
-          "https://type.example/Song"
-        ]
-      }
-    ]
-  }
+  "permission": [
+    {
+      "action": "read",
+      "target": "https://storage.example/data/",
+      "assignee": "https://id.example/agent",
+      "constraint": [
+        {
+          "leftOperand": "type",
+          "operator": "isAnyOf",
+          "rightOperand": [
+            "https://type.example/Playlist",
+            "https://type.example/Song"
+          ]
+        }
+      ]
+    }
+  ]
+}
+          </pre>
+        </section>
+
+        <section id="constraint-purpose">
+          <h4>Purpose Constraints</h4>
+
+          <p>
+            The <code>purpose</code> left operand (defined by [[!ODRL-VOCAB]]) describes
+            the intended use of the access. The <code>rightOperand</code> value MUST be a
+            URI identifying a purpose:
+          </p>
+
+          <pre class="example" title="Purpose constraint">
+{
+  "permission": [
+    {
+      "action": "read",
+      "target": "https://storage.example/projects/",
+      "assignee": "https://id.example/agent",
+      "constraint": [
+        {
+          "leftOperand": "purpose",
+          "operator": "eq",
+          "rightOperand": "https://purpose.example/collaboration"
+        }
+      ]
+    }
+  ]
 }
           </pre>
         </section>
@@ -686,29 +948,33 @@ Link: &lt;https://type.example/Playlist&gt;; rel="type"
 
           <p>
             The following example uses a <code>leftOperand</code> value of
-            <code>dateTime</code> to limit access
-            to a specific time window. The <code>gteq</code> operator defines the start of the
-            window and the <code>lteq</code> operator defines the end. The
-            <code>rightOperand</code> value for temporal constraints is an
-            [[!XMLSCHEMA11-2|XML Schema]] <code>dateTime</code> string:
+            <code>dateTime</code> to limit access to a specific time window. The
+            <code>gteq</code> operator defines the start and the <code>lteq</code>
+            operator defines the end. The <code>rightOperand</code> value for temporal
+            constraints is an [[!XMLSCHEMA11-2|XML Schema]] <code>dateTime</code> string:
           </p>
 
           <pre class="example" title="Temporal constraint">
 {
-  "access": {
-    "constraint": [
-      {
-        "leftOperand": "dateTime",
-        "operator": "gteq",
-        "rightOperand": "2026-03-09T12:00:00Z"
-      },
-      {
-        "leftOperand": "dateTime",
-        "operator": "lteq",
-        "rightOperand": "2026-06-09T10:00:00Z"
-      }
-    ]
-  }
+  "permission": [
+    {
+      "action": "read",
+      "target": "https://storage.example/projects/",
+      "assignee": "https://id.example/agent",
+      "constraint": [
+        {
+          "leftOperand": "dateTime",
+          "operator": "gteq",
+          "rightOperand": "2026-03-09T12:00:00Z"
+        },
+        {
+          "leftOperand": "dateTime",
+          "operator": "lteq",
+          "rightOperand": "2026-06-09T10:00:00Z"
+        }
+      ]
+    }
+  ]
 }
           </pre>
         </section>
@@ -717,33 +983,100 @@ Link: &lt;https://type.example/Playlist&gt;; rel="type"
           <h4>Combining Constraints</h4>
 
           <p>
-            When multiple constraint objects are present, all of them MUST be satisfied for
-            access to be permitted. The following example restricts access to a specific client
-            application before a specific date:
+            When multiple constraint objects are present on a rule, all of them MUST be
+            satisfied for the rule to apply. The following example restricts a permission
+            to a specific client application before a specific date:
           </p>
 
           <pre class="example" title="Combined constraints">
 {
+  "permission": [
+    {
+      "action": "read",
+      "target": "https://storage.example/projects/",
+      "assignee": "https://id.example/agent",
+      "constraint": [
+        {
+          "leftOperand": "dateTime",
+          "operator": "lteq",
+          "rightOperand": "2026-06-09T10:00:00Z"
+        },
+        {
+          "leftOperand": "client",
+          "operator": "eq",
+          "rightOperand": "https://app.example/client-id"
+        }
+      ]
+    }
+  ]
+}
+          </pre>
+        </section>
+      </section>
+
+      <section id="profile-prohibitions-obligations">
+        <h3>Prohibitions and Obligations</h3>
+
+        <p>
+          In addition to permissions, this profile supports prohibitions and obligations.
+        </p>
+
+        <p>
+          A <strong>prohibition</strong> explicitly denies an action. This is useful when
+          broad permissions are granted but specific operations must be excluded:
+        </p>
+
+        <pre class="example" title="Permission with prohibition">
+{
   "access": {
-    "action": ["read"],
-    "assignee": "https://id.example/agent",
-    "target": ["https://storage.example/projects/"],
-    "constraint": [
+    "type": ["ODRLAccessPolicy"],
+    "profile": "https://www.w3.org/ns/lws#ODRLAccessProfile",
+    "permission": [
       {
-        "leftOperand": "dateTime",
-        "operator": "lteq",
-        "rightOperand": "2026-06-09T10:00:00Z"
-      },
+        "action": "read",
+        "target": "https://storage.example/projects/",
+        "assignee": "https://id.example/agent"
+      }
+    ],
+    "prohibition": [
       {
-        "leftOperand": "client",
-        "operator": "eq",
-        "rightOperand": "https://app.example/client-id"
+        "action": "read",
+        "target": "https://storage.example/projects/confidential/",
+        "assignee": "https://id.example/agent"
       }
     ]
   }
 }
-          </pre>
-        </section>
+        </pre>
+
+        <p>
+          An <strong>obligation</strong> expresses a duty that MUST be fulfilled in
+          conjunction with the granted permissions. The interpretation and enforcement of
+          obligations is implementation-specific:
+        </p>
+
+        <pre class="example" title="Permission with obligation">
+{
+  "access": {
+    "type": ["ODRLAccessPolicy"],
+    "profile": "https://www.w3.org/ns/lws#ODRLAccessProfile",
+    "permission": [
+      {
+        "action": "modify",
+        "target": "https://storage.example/projects/",
+        "assignee": "https://id.example/agent"
+      }
+    ],
+    "obligation": [
+      {
+        "action": "read",
+        "target": "https://storage.example/projects/policy.html",
+        "assignee": "https://id.example/agent"
+      }
+    ]
+  }
+}
+        </pre>
       </section>
     </section>
 

--- a/lws10-access-requests/index.html
+++ b/lws10-access-requests/index.html
@@ -20,7 +20,7 @@
         github: "w3c/lws-protocol",
         xref: ["web-platform"],
         group: "lws",
-        maxTocLevel: 2,
+        maxTocLevel: 4,
         localBiblio: {
           "LWS-PROTOCOL": {
             title: "LWS Protocol",
@@ -75,8 +75,8 @@
 
       <p>
         The <a>access policy profile</a> defined in this document is based on concepts from the
-        <a href="https://www.w3.org/TR/odrl-model/">Open Digital Rights Language</a> (ODRL), including
-        actions, constraints, and assignees. Other profiles could use a different conceptual framework.
+        <a href="https://www.w3.org/TR/odrl-model/">Open Digital Rights Language</a> (ODRL).
+        Other profiles could use a different conceptual framework.
       </p>
     </section>
 
@@ -96,7 +96,7 @@
           purposes and constraints.
         </li>
         <li>
-          <dfn>Access Grant</dfn> &mdash; a JSON-LD object created by a storage manager, expressing
+          <dfn>Access Grant</dfn> &mdash; a JSON-LD object created by a <a>storage manager</a>, expressing
           an ability for an agent to perform specific actions on storage resources within certain
           defined constraints and for specific purposes.
         </li>
@@ -105,6 +105,11 @@
           requirements for expressing a valid access policy. Every access policy profile is identified
           with a URI, and a server indicates support for an access control policy profile by
           referencing it with a <code>conformsTo</code> property in a Storage Description resource.
+        </li>
+        <li>
+          <dfn>Storage Manager</dfn> &mdash; an agent with administrative control over a
+          storage, responsible for reviewing <a>access requests</a> and creating
+          <a>access grants</a>.
         </li>
       </ul>
     </section>
@@ -171,7 +176,7 @@
   "inbox": "https://id.example/agent/inbox/",
   "storage": "https://storage.example/",
   "access": {
-    "type": ["ODRLAccessPolicy"],
+    "type": ["Request"],
     "profile": "https://www.w3.org/ns/lws#ODRLAccessProfile",
     "permission": [
       {
@@ -213,8 +218,7 @@
   "type": ["AccessGrant"],
   "storage": "https://storage.example/",
   "access": {
-    "type": ["ODRLAccessPolicy"],
-    "uid": "urn:uuid:e6a09a85-3f72-4e6d-bcd3-7e4a0e6378a2",
+    "type": ["Offer"],
     "profile": "https://www.w3.org/ns/lws#ODRLAccessProfile",
     "permission": [
       {
@@ -292,7 +296,7 @@
             <code>AccessRequest</code> &mdash; a request by an agent for access to resources.
           </li>
           <li>
-            <code>AccessGrant</code> &mdash; an authorization by a storage manager granting
+            <code>AccessGrant</code> &mdash; an authorization by a <a>storage manager</a> granting
             access to resources.
           </li>
         </ul>
@@ -385,8 +389,12 @@
       <p>
         The <code>access</code> object of an <a>access request</a> or <a>access grant</a>
         conforming to this profile is an ODRL
-        <a href="https://www.w3.org/TR/odrl-model/#policy-set">Policy</a> containing one or more
-        rules. Each rule is a
+        <a href="https://www.w3.org/TR/odrl-model/#policy-subclasses">Policy</a> containing
+        one or more rules. For an <a>access request</a>, the policy is an
+        <a href="https://www.w3.org/TR/odrl-model/#request">ODRL Request</a>; for an
+        <a>access grant</a>, it is an
+        <a href="https://www.w3.org/TR/odrl-model/#offer">ODRL Offer</a>.
+        Each rule is a
         <a href="https://www.w3.org/TR/odrl-model/#permission">Permission</a>,
         <a href="https://www.w3.org/TR/odrl-model/#prohibition">Prohibition</a>, or
         <a href="https://www.w3.org/TR/odrl-model/#obligation">Obligation</a>.
@@ -479,9 +487,12 @@ lws:append a odrl:Action, skos:Concept ;
             <li><code>client</code> &mdash; the client identifier for an HTTP request.
               Defined by this specification.</li>
             <li><code>mediaType</code> &mdash; the media type of the target HTTP resource.
+              Reuses the <code>as:mediaType</code> term from
+              [[ACTIVITY-STREAMS-VOCABULARY]].</li>
+            <li><code>resourceType</code> &mdash; the type URL expressed in a resource's link headers.
               Defined by this specification.</li>
-            <li><code>type</code> &mdash; the type URL expressed in a resource's link headers.
-              Defined by this specification.</li>
+            <li><code>issuer</code> &mdash; the identity provider (issuer) that authenticated
+              the requesting agent. Defined by this specification.</li>
           </ul>
 
           <p>
@@ -499,15 +510,44 @@ lws:client a odrl:LeftOperand, skos:Concept ;
     skos:definition "The client identifier for an HTTP request."@en ;
     skos:note "Used to restrict access to specific client applications."@en .
 
-lws:mediaType a odrl:LeftOperand, skos:Concept ;
-    rdfs:label "Media Type"@en ;
-    skos:definition "The media type of the target HTTP resource."@en ;
-    skos:note "Used to restrict access based on IANA media types."@en .
-
-lws:type a odrl:LeftOperand, skos:Concept ;
+lws:resourceType a odrl:LeftOperand, skos:Concept ;
     rdfs:label "Resource Type"@en ;
     skos:definition "The type URL expressed in a resource's link headers."@en ;
     skos:note "Used to restrict access based on Link rel=type headers."@en .
+
+lws:issuer a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "Issuer"@en ;
+    skos:definition "The identity provider (issuer) that authenticated the requesting agent."@en ;
+    skos:note "Used to restrict access based on the agent's identity provider."@en .
+          </pre>
+        </section>
+
+        <section id="vocab-party-classes">
+          <h4>Party Classes</h4>
+
+          <p>
+            The following class is defined by this specification for use as an
+            <code>assignee</code> value:
+          </p>
+
+          <ul>
+            <li><code>Creator</code> &mdash; the agent that originally created the target
+              resource. Defined by this specification.</li>
+          </ul>
+
+          <p>
+            The formal RDF definition is:
+          </p>
+
+          <pre class="example nohighlight" title="LWS ODRL Profile party classes (Turtle)">
+@prefix lws:  &lt;https://www.w3.org/ns/lws#&gt; .
+@prefix rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt; .
+@prefix skos: &lt;http://www.w3.org/2004/02/skos/core#&gt; .
+
+lws:Creator a rdfs:Class, skos:Concept ;
+    rdfs:label "Creator"@en ;
+    skos:definition "The agent that originally created the target resource."@en ;
+    skos:note "Used as an assignee value to grant access to the resource creator."@en .
           </pre>
         </section>
       </section>
@@ -530,16 +570,18 @@ lws:type a odrl:LeftOperand, skos:Concept ;
 {
   "@context": {
     "lws":  "https://www.w3.org/ns/lws#",
+    "as":   "https://www.w3.org/ns/activitystreams#",
     "odrl": "http://www.w3.org/ns/odrl/2/",
     "xsd":  "http://www.w3.org/2001/XMLSchema#",
 
-    "AccessRequest":     "lws:AccessRequest",
-    "AccessGrant":       "lws:AccessGrant",
-    "ODRLAccessPolicy":  "lws:ODRLAccessPolicy",
+    "AccessRequest":  "lws:AccessRequest",
+    "AccessGrant":    "lws:AccessGrant",
+    "Request":        "odrl:Request",
+    "Offer":          "odrl:Offer",
+    "Creator":        "lws:Creator",
 
     "access":      "lws:access",
     "profile":     "odrl:profile",
-    "uid":         "odrl:uid",
     "permission":  { "@id": "odrl:permission",  "@container": "@set" },
     "prohibition": { "@id": "odrl:prohibition", "@container": "@set" },
     "obligation":  { "@id": "odrl:obligation",  "@container": "@set" },
@@ -552,18 +594,23 @@ lws:type a odrl:LeftOperand, skos:Concept ;
     "operator":     "odrl:operator",
     "rightOperand": "odrl:rightOperand",
 
-    "read":      "odrl:read",
-    "modify":    "odrl:modify",
-    "delete":    "odrl:delete",
-    "create":    "lws:create",
-    "append":    "lws:append",
-    "dateTime":  "odrl:dateTime",
-    "purpose":   "odrl:purpose",
-    "client":    "lws:client",
-    "mediaType": "lws:mediaType",
-    "type":      "lws:type",
+    "storage":   { "@id": "lws:storage", "@type": "@id" },
+    "inbox":     { "@id": "lws:inbox",   "@type": "@id" },
+
+    "read":          "odrl:read",
+    "modify":        "odrl:modify",
+    "delete":        "odrl:delete",
+    "create":        "lws:create",
+    "append":        "lws:append",
+    "dateTime":      "odrl:dateTime",
+    "purpose":       "odrl:purpose",
+    "client":        "lws:client",
+    "mediaType":     "as:mediaType",
+    "resourceType":  "lws:resourceType",
+    "issuer":        "lws:issuer",
 
     "eq":       "odrl:eq",
+    "gt":       "odrl:gt",
     "lt":       "odrl:lt",
     "lteq":     "odrl:lteq",
     "gteq":     "odrl:gteq",
@@ -587,7 +634,7 @@ lws:type a odrl:LeftOperand, skos:Concept ;
   "@context": "https://www.w3.org/ns/lws/v1",
   "type": {},
   "access": {
-    "type": "ODRLAccessPolicy",
+    "type": {},
     "permission": {
       "action": {},
       "target": {},
@@ -622,15 +669,16 @@ lws:type a odrl:LeftOperand, skos:Concept ;
         <ul>
           <li>
             <code>type</code> &mdash; REQUIRED. MUST be an array of strings that includes
-            <code>ODRLAccessPolicy</code>. Additional type values MAY be included.
+            the appropriate ODRL policy subclass. For an <a>access request</a>, the array
+            MUST contain <code>Request</code> (an
+            <a href="https://www.w3.org/TR/odrl-model/#request">ODRL Request</a>). For an
+            <a>access grant</a>, the array MUST contain <code>Offer</code> (an
+            <a href="https://www.w3.org/TR/odrl-model/#offer">ODRL Offer</a>).
+            Additional type values MAY be included.
           </li>
           <li>
             <code>profile</code> &mdash; REQUIRED. MUST be the string
             <code>https://www.w3.org/ns/lws#ODRLAccessProfile</code>.
-          </li>
-          <li>
-            <code>uid</code> &mdash; OPTIONAL. A URI that uniquely identifies the policy.
-            Servers SHOULD assign a <code>uid</code> when creating an <a>access grant</a>.
           </li>
           <li>
             <code>permission</code> &mdash; an array of Permission rules.
@@ -648,10 +696,10 @@ lws:type a odrl:LeftOperand, skos:Concept ;
           <code>obligation</code> MUST be present.
         </p>
 
-        <pre class="example" title="ODRL Access Policy">
+        <pre class="example" title="ODRL Access Policy (in an access grant)">
 {
   "access": {
-    "type": ["ODRLAccessPolicy"],
+    "type": ["Offer"],
     "profile": "https://www.w3.org/ns/lws#ODRLAccessProfile",
     "permission": [
       {
@@ -714,6 +762,21 @@ lws:type a odrl:LeftOperand, skos:Concept ;
           </p>
 
           <p>
+            The <code>assignee</code> value MAY also reference an ODRL
+            <a href="https://www.w3.org/TR/odrl-model/#party">Party Collection</a>,
+            which represents a group of agents. This allows a single rule to apply to
+            all members of a group.
+          </p>
+
+          <p>
+            To grant access to the agent that created a resource, the <code>assignee</code>
+            value MAY use the <code>Creator</code> class
+            (<code>https://www.w3.org/ns/lws#Creator</code>) defined by this
+            specification. The server MUST resolve this to the agent that originally
+            created the target resource.
+          </p>
+
+          <p>
             This property is REQUIRED.
           </p>
 
@@ -723,6 +786,42 @@ lws:type a odrl:LeftOperand, skos:Concept ;
     {
       "action": "read",
       "assignee": "https://id.example/agent"
+    }
+  ]
+}
+          </pre>
+
+          <pre class="example" title="Assignee as a group (Party Collection)">
+{
+  "permission": [
+    {
+      "action": "read",
+      "target": "https://storage.example/projects/",
+      "assignee": "https://groups.example/engineering-team"
+    }
+  ]
+}
+          </pre>
+
+          <pre class="example" title="Public access using foaf:Agent">
+{
+  "permission": [
+    {
+      "action": "read",
+      "target": "https://storage.example/public/",
+      "assignee": "http://xmlns.com/foaf/0.1/Agent"
+    }
+  ]
+}
+          </pre>
+
+          <pre class="example" title="Creator access using lws:Creator">
+{
+  "permission": [
+    {
+      "action": "read",
+      "target": "https://storage.example/projects/",
+      "assignee": "https://www.w3.org/ns/lws#Creator"
     }
   ]
 }
@@ -782,8 +881,8 @@ lws:type a odrl:LeftOperand, skos:Concept ;
             </li>
             <li>
               <code>operator</code> &mdash; a string identifying the comparison operator.
-              Supported values include: <code>eq</code>, <code>lt</code>, <code>lteq</code>,
-              <code>gteq</code>, and <code>isAnyOf</code>.
+              Supported values include: <code>eq</code>, <code>gt</code>, <code>lt</code>,
+              <code>lteq</code>, <code>gteq</code>, and <code>isAnyOf</code>.
             </li>
             <li>
               <code>rightOperand</code> &mdash; the value to compare against. The type
@@ -884,8 +983,8 @@ Link: &lt;https://type.example/Playlist&gt;; rel="type"
 
           <p>
             The following example uses a <code>leftOperand</code> value of
-            <code>type</code> to restrict access based on the resource types advertised
-            in HTTP <code>Link</code> headers.
+            <code>resourceType</code> to restrict access based on the resource types
+            advertised in HTTP <code>Link</code> headers.
             When the <code>isAnyOf</code> operator is used, the <code>rightOperand</code>
             value is an array of type URIs, and access is permitted if the resource's type
             matches any of the listed values:
@@ -900,7 +999,7 @@ Link: &lt;https://type.example/Playlist&gt;; rel="type"
       "assignee": "https://id.example/agent",
       "constraint": [
         {
-          "leftOperand": "type",
+          "leftOperand": "resourceType",
           "operator": "isAnyOf",
           "rightOperand": [
             "https://type.example/Playlist",
@@ -979,6 +1078,40 @@ Link: &lt;https://type.example/Playlist&gt;; rel="type"
           </pre>
         </section>
 
+        <section id="constraint-issuer">
+          <h4>Issuer Constraints</h4>
+
+          <p>
+            The <code>issuer</code> left operand restricts access based on the identity
+            provider that authenticated the requesting agent. The
+            <code>rightOperand</code> value MUST be a URI identifying the issuer. When the
+            <code>isAnyOf</code> operator is used, access is permitted if the agent was
+            authenticated by any of the listed issuers:
+          </p>
+
+          <pre class="example" title="Issuer constraint">
+{
+  "permission": [
+    {
+      "action": "read",
+      "target": "https://storage.example/projects/",
+      "assignee": "https://id.example/agent",
+      "constraint": [
+        {
+          "leftOperand": "issuer",
+          "operator": "isAnyOf",
+          "rightOperand": [
+            "https://idp.example/",
+            "https://trusted-provider.example/"
+          ]
+        }
+      ]
+    }
+  ]
+}
+          </pre>
+        </section>
+
         <section id="constraint-combining">
           <h4>Combining Constraints</h4>
 
@@ -1029,7 +1162,7 @@ Link: &lt;https://type.example/Playlist&gt;; rel="type"
         <pre class="example" title="Permission with prohibition">
 {
   "access": {
-    "type": ["ODRLAccessPolicy"],
+    "type": ["Offer"],
     "profile": "https://www.w3.org/ns/lws#ODRLAccessProfile",
     "permission": [
       {
@@ -1058,7 +1191,7 @@ Link: &lt;https://type.example/Playlist&gt;; rel="type"
         <pre class="example" title="Permission with obligation">
 {
   "access": {
-    "type": ["ODRLAccessPolicy"],
+    "type": ["Offer"],
     "profile": "https://www.w3.org/ns/lws#ODRLAccessProfile",
     "permission": [
       {
@@ -1095,21 +1228,28 @@ Link: &lt;https://type.example/Playlist&gt;; rel="type"
 
       <p>
         An agent creates an <a>access request</a> by submitting a <code>POST</code> request to the
-        <a>access request</a> endpoint. A storage manager creates an <a>access grant</a> by
+        <a>access request</a> endpoint. A <a>storage manager</a> creates an <a>access grant</a> by
         submitting a <code>POST</code> request to the <a>access grant</a> endpoint.
       </p>
 
       <p>
-        For POST operations, a server MUST validate the request body, rejecting any invalid
-        requests with an error response. A successful POST operation MUST respond with a
-        <code>Location</code> header set to the URL of the new resource.
+        A POST request MUST include a <code>Content-Type</code> header with a value of
+        <code>application/ld+json</code>.
+      </p>
+
+      <p>
+        For POST operations, a server MUST validate the request body. If the request body is
+        invalid, the server MUST respond with a <code>400 Bad Request</code> status code. If a
+        valid request contains values that the server cannot represent in its underlying access
+        policy layer, the server MUST respond with a <code>422 Unprocessable Content</code>
+        status code. A successful POST operation MUST respond with a <code>201 Created</code>
+        status code and a <code>Location</code> header set to the URL of the new resource.
       </p>
 
       <p class="note">
-        When a storage manager processes an <a>access request</a>, either by creating an
-        <a>access grant</a> or by rejecting the request, deleting the original request can help
-        keep the request container
-        more manageable.
+        When a <a>storage manager</a> processes an <a>access request</a>, either by creating
+        an <a>access grant</a> or by rejecting the request, deleting the original request can
+        help keep the request container more manageable.
       </p>
 
       <section id="access-request-endpoint">
@@ -1145,10 +1285,10 @@ Link: &lt;https://type.example/Playlist&gt;; rel="type"
           Each endpoint contains <a>access requests</a> and <a>access grants</a> received on
           behalf of a storage. The
           server SHOULD filter the content of these containers according to the requester's
-          permission. In general, the storage manager will have the ability to read and delete
-          all resources while other users will only have access to the resources for which they
-          are the assignee. Non-owner users might have the ability to delete access requests
-          that they created.
+          permission. In general, the <a>storage manager</a> will have the ability to read
+          and delete all resources while other users will only have access to the resources
+          for which they are the assignee. Non-owner users might have the ability to delete
+          access requests that they created.
         </p>
       </section>
 
@@ -1161,6 +1301,12 @@ Link: &lt;https://type.example/Playlist&gt;; rel="type"
           profile. A server MUST reject any
           payload that cannot be represented fully in its underlying access policy layer.
         </p>
+
+        <p>
+          When validating an <a>access request</a> or <a>access grant</a>, a server SHOULD
+          verify that any <code>target</code> URI references a resource within the scope of the
+          advertised <code>storage</code>.
+        </p>
       </section>
     </section>
 
@@ -1172,7 +1318,7 @@ Link: &lt;https://type.example/Playlist&gt;; rel="type"
       </p>
 
       <p>
-        Notifications provide a mechanism for informing agents and storage managers about changes to
+        Notifications provide a mechanism for informing agents and <a>storage managers</a> about changes to
         <a>access requests</a> and <a>access grants</a>. When an <code>inbox</code> property is
         present on an <a>access request</a> or <a>access grant</a>, the server SHOULD deliver
         notifications to that endpoint, informing an
@@ -1206,12 +1352,17 @@ Link: &lt;https://type.example/Playlist&gt;; rel="type"
         <ul>
           <li>
             <strong>Access Request creation</strong>: When a new <a>access request</a> is
-            submitted, the storage manager SHOULD be notified.
+            submitted, the <a>storage manager</a> SHOULD be notified.
           </li>
           <li>
             <strong>Access Grant creation</strong>: When a new <a>access grant</a> is created,
             the requesting agent SHOULD be notified at the <code>inbox</code> specified in
             the associated <a>access request</a>.
+          </li>
+          <li>
+            <strong>Access Grant revocation</strong>: When an <a>access grant</a> is deleted
+            (revoked), the affected agent SHOULD be notified at the <code>inbox</code>
+            specified in the associated <a>access grant</a> or <a>access request</a>.
           </li>
         </ul>
 
@@ -1226,13 +1377,19 @@ Link: &lt;https://type.example/Playlist&gt;; rel="type"
 
       <ul>
         <li>
-          Servers are encouraged to restrict which clients are able to perform POST operations
-          on the <a>access grant</a> endpoint.
+          A server SHOULD restrict which clients are able to perform POST operations
+          on the <a>access grant</a> endpoint to the <a>storage manager</a> or
+          appropriately authorized agents.
         </li>
         <li>
-          When an agent creates an <a>access request</a>, the server is encouraged to verify
+          When an agent creates an <a>access request</a>, a server SHOULD verify
           that the <code>assignee</code> value in the request is associated with the
           authenticated identity of the requesting agent.
+        </li>
+        <li>
+          A server SHOULD validate that any <code>target</code> URI in an <a>access request</a>
+          or <a>access grant</a> is within the scope of the associated storage, to prevent
+          an agent from crafting requests that reference external resources.
         </li>
       </ul>
     </section>
@@ -1244,7 +1401,7 @@ Link: &lt;https://type.example/Playlist&gt;; rel="type"
         <li>
           An <a>access request</a> or <a>access grant</a> can reveal sensitive information
           about the resources, agents, and purposes involved. Servers are encouraged to limit
-          the visibility of these resources to authorized parties, such as the storage manager
+          the visibility of these resources to authorized parties, such as the <a>storage manager</a>
           and the assignee identified in the document.
         </li>
         <li>

--- a/lws10-access-requests/index.html
+++ b/lws10-access-requests/index.html
@@ -398,10 +398,19 @@
         <p>
           The value of the <code>action</code> property MUST be a non-empty array of strings.
           Each value MUST correspond to an operation recognized by the server. The following
-          values MUST be supported: <code>read</code>, <code>modify</code>, <code>create</code>,
-          and <code>delete</code>. The <code>read</code>, <code>modify</code>, and
-          <code>delete</code> values are defined by the [[!ODRL-VOCAB|ODRL Vocabulary]]. The
-          <code>create</code> value is defined by this specification.
+          values MUST be supported: <code>read</code>, <code>modify</code>, <code>append</code>,
+          <code>create</code>, and <code>delete</code>. The <code>read</code>,
+          <code>modify</code>, and <code>delete</code> values are defined by the
+          [[!ODRL-VOCAB|ODRL Vocabulary]]. The <code>create</code> and <code>append</code>
+          values are defined by this specification.
+        </p>
+
+        <p>
+          The <code>append</code> action is defined as
+          <a href="https://www.w3.org/TR/odrl-vocab/#term-includedIn">included in</a>
+          <code>modify</code>. This means that granting <code>modify</code> implicitly
+          includes <code>append</code>, but granting <code>append</code> alone does not
+          permit full modification of a resource.
         </p>
 
         <p>
@@ -411,6 +420,10 @@
         <ul>
           <li><code>read</code> &mdash; retrieve a resource or its metadata (HTTP GET, HEAD)</li>
           <li><code>modify</code> &mdash; modify an existing resource (HTTP PUT, PATCH)</li>
+          <li>
+            <code>append</code> &mdash; add content to an existing resource without removing
+            or replacing existing content (HTTP PATCH, insert-only)
+          </li>
           <li>
             <code>create</code> &mdash; create a new resource within a container (HTTP POST)
           </li>


### PR DESCRIPTION
@acoburn if you are approving of these changes, I suggest we merge them into your PR ASAP and continue discussion there -- rather than having two threads of discussion on Access Grants.

### Summary

This branch restructures the LWS Access Requests and Access Grants specification to properly align with the ODRL Information Model. The flat `access` object is replaced with a standards-compliant ODRL Policy structure using `permission`/`prohibition`/`obligation` rules, a formal profile vocabulary is defined, and JSON-LD context and framing are specified.

### Changes

#### ODRL Policy Structure (breaking change to data model)

- **Rule-based access policies**: The `access` object is now a proper ODRL Policy containing `permission`, `prohibition`, and `obligation` arrays. Each rule carries its own `action`, `target`, `assignee`, and `constraint` — replacing the previous flat structure where these were top-level properties on the policy.
- **ODRL Policy subclasses**: Access requests use `odrl:Request`; access grants use `odrl:Offer`. The previous `ODRLAccessPolicy` type on the access object is replaced with these standard ODRL policy subclass types.
- **`profile` property**: Every access policy now includes a required `profile` property (`https://www.w3.org/ns/lws#ODRLAccessProfile`) per the ODRL profile mechanism.
- **Singular action per rule**: `action` is now a single string per rule instead of an array on the policy, allowing fine-grained constraint attachment per operation.
- **Singular target per rule**: `target` is now a single URI per rule instead of an array on the policy.

#### `hasPurpose` → `purpose` constraint

- The non-standard `hasPurpose` top-level property is removed. Purpose is now expressed as an ODRL constraint using the existing `odrl:purpose` left operand — consistent with how other conditions (temporal, client, etc.) are expressed.

#### New vocabulary terms

- **`lws:append` action**: A new action defined as `odrl:includedIn odrl:modify`. Granting `modify` implicitly includes `append`, but `append` alone permits only insert-only PATCH operations.
- **`lws:create` action**: Defined as `odrl:includedIn odrl:use`. Corresponds to HTTP POST on an LWS container.
- **`lws:resourceType` left operand**: Renamed from `type` to avoid collision with `rdf:type`/JSON-LD `@type`.
- **`lws:issuer` left operand**: New constraint for restricting access based on the identity provider that authenticated the agent.
- Formal Turtle definitions with `rdfs:label`, `skos:definition`, `skos:note` for all profile-specific terms.

#### New specification sections

- **Vocabulary** (§3.1): Formal definitions of all profile actions and left operands, including RDF/Turtle.
- **JSON-LD Context** (§3.2): Full context excerpt mapping short-form property names to IRIs.
- **JSON-LD Frame** (§3.3): A JSON-LD 1.1 Frame for deterministic deserialization of access documents.
- **Policy** (§3.4): Normative definition of the Policy object (`type`, `profile`, rule arrays).
- **Rules** (§3.5): Properties on Permission/Prohibition/Obligation (action, assignee, target, constraint).
- **Prohibitions and Obligations** (§3.7): New examples showing prohibition (deny a subtree) and obligation (duty) rules.
- **Groups** (§3.8): Support for defining agent groups in access policies using `vcard:Group`.

#### Editorial / structural

- Added `Storage Manager` to terminology with a formal definition.
- Changed `storage manager` references to use the `<a>storage manager</a>` dfn link.
- Added `JSON-LD11-FRAMING` and `VCARD-RDF` to `localBiblio`.
- Increased `maxTocLevel` from 2 to 4 to expose the new subsection hierarchy.
- Updated all examples throughout the document to use the new rule-based structure.
