### PR TITLE
Agenda for April F2F meetings

### DIFF
--- a/apr26-meeting/agenda.md
+++ b/apr26-meeting/agenda.md
@@ -1,0 +1,36 @@
+# April 2026 LWS Face-to-face Meeting
+
+Dates: 2026-04-27 to 2026-04-28
+Location: Open Data Institute, London, UK
+
+## Agenda
+
+### Monday, April 27
+
+[W3C Calendar](https://www.w3.org/events/meetings/fed3ebd2-1330-4853-8ec4-12442c47e32c/)
+
+* WG Future - the WG charter expires in Sept 2026, this segment is to discuss what comes next
+  * Goals and strategy
+  * Interaction with Solid CG and external stakeholders
+  * Charter process and timeline
+* Recommendation Track documents - open work items that need attention
+  * Access Requests
+  * Type Index
+  * Notifications
+  * Test Suite and reference implementation
+
+### Tuesday, April 28
+
+[W3C Calendar](https://www.w3.org/events/meetings/10c363c4-c825-4d24-b2cb-bf70af152298/)
+
+* Recommendation Track documents - items missing from specification documents
+  * Terminology
+  * Metadata resources
+* Non-recommendation Track documents
+  * Use cases and requirements
+  * LWS Primer
+  * LWS Best Practices
+* Editorial - identify areas of inconsistency across documents
+* Clarify and/or resolve open issues in GitHub repository
+
+

--- a/apr26-meeting/agenda.md
+++ b/apr26-meeting/agenda.md
@@ -13,25 +13,25 @@ Location: Open Data Institute, London, UK
   * Goals and strategy
   * Interaction with Solid CG and external stakeholders
   * Charter process and timeline
-* Recommendation Track documents - open work items that need attention
+* Recommendation Track documents
   * Access Requests (not too late)
   * Notifications (not too late)
-  * Terminology (After lunch)
-  * Type Index (After lunch)
+  * Containers (after lunch)
+  * Terminology (after lunch)
+  * Type Index (after lunch)
   * Test Suite and example implementation
 
 ### Tuesday, April 28
 
 [W3C Calendar](https://www.w3.org/events/meetings/10c363c4-c825-4d24-b2cb-bf70af152298/)
 
-* Recommendation Track documents - items missing from specification documents
+* Recommendation Track documents
   * Metadata resources
 * Non-recommendation Track documents
   * Use cases and requirements
   * LWS Primer
   * LWS Best Practices
   * Solid Compatability Document
-* Editorial - identify areas of inconsistency across documents
-* Clarify and/or resolve open issues in GitHub repository
+
 
 

--- a/apr26-meeting/agenda.md
+++ b/apr26-meeting/agenda.md
@@ -19,7 +19,6 @@ Location: Open Data Institute, London, UK
   * Containers (after lunch)
   * Terminology (after lunch)
   * Type Index (after lunch)
-  * Test Suite and example implementation
 
 ### Tuesday, April 28
 
@@ -27,6 +26,7 @@ Location: Open Data Institute, London, UK
 
 * Recommendation Track documents
   * Metadata resources
+* Test Suite and example implementation
 * Non-recommendation Track documents
   * Use cases and requirements
   * LWS Primer

--- a/apr26-meeting/agenda.md
+++ b/apr26-meeting/agenda.md
@@ -17,7 +17,7 @@ Location: Open Data Institute, London, UK
   * Access Requests
   * Type Index
   * Notifications
-  * Test Suite and reference implementation
+  * Test Suite and example implementation
 
 ### Tuesday, April 28
 
@@ -30,6 +30,7 @@ Location: Open Data Institute, London, UK
   * Use cases and requirements
   * LWS Primer
   * LWS Best Practices
+  * Solid Compatability Document
 * Editorial - identify areas of inconsistency across documents
 * Clarify and/or resolve open issues in GitHub repository
 

--- a/apr26-meeting/agenda.md
+++ b/apr26-meeting/agenda.md
@@ -14,9 +14,10 @@ Location: Open Data Institute, London, UK
   * Interaction with Solid CG and external stakeholders
   * Charter process and timeline
 * Recommendation Track documents - open work items that need attention
-  * Access Requests
-  * Type Index
-  * Notifications
+  * Access Requests (not too late)
+  * Notifications (not too late)
+  * Terminology (After lunch)
+  * Type Index (After lunch)
   * Test Suite and example implementation
 
 ### Tuesday, April 28
@@ -24,7 +25,6 @@ Location: Open Data Institute, London, UK
 [W3C Calendar](https://www.w3.org/events/meetings/10c363c4-c825-4d24-b2cb-bf70af152298/)
 
 * Recommendation Track documents - items missing from specification documents
-  * Terminology
   * Metadata resources
 * Non-recommendation Track documents
   * Use cases and requirements


### PR DESCRIPTION
This PR includes a draft agenda for the April, 2026, face-to-face meeting at the ODI.

The ordering of items generally aims to reflect priority while also considering that some folks may be joining remotely from different time zones.

Questions for anyone reviewing this:

1. Are there items missing from this list?
2. Are there items listed here that could be omitted (e.g., the last two items on Tuesday)
3. Is there a better order for these items?