### PR TITLE
Terminology section formatting fixes

### DIFF
--- a/lws10-core/index.html
+++ b/lws10-core/index.html
@@ -173,54 +173,53 @@
       </section>
     </section>
 
-    <section id="terminology">
-      <h2>Terminology</h2>
-      <p>
-        The terms "authorization server" and "client" are defined by the OAuth 2.0 Authorization Framework [[!RFC6749]].
-      <p>
-      <p>
-        The terms "end-user" and "issuer" are defined by OpenID Connect Core 1.0 [[!OPENID-CONNECT-CORE]].
-      </p>
-
-      <p>
-        This specification defines the following terms:
-      </p>
-      <ul>
-        <li><dfn>authentication credential</dfn> &mdash; a security token that asserts claims about an agent or end-user. This token is secured with a cryptographic proof.
-          Examples of an authentication credentials include assertions of identity such as OpenID Connect ID Tokens and SAML-based assertions as well as assertions of
-          capability such as a ZCAP.
-        </li>
-        <li><dfn>authentication suite</dfn> &mdash; a defined validation mechanism for a concrete serialization of an authentication credential.</li>
-        <li><dfn>LWS resource</dfn> &mdash; An LWS Resource is an <a href="https://www.w3.org/TR/webarch/#def-information-resource">information resource</a> whose lifecycle is managed by the LWS storage.</li>
-        <li><dfn>container</dfn> &mdash; An LWS resource that maintains links to a set of contained resources whose lifecycle is governed by the same LWS server. Containers serve as organizational units enabling clients to group, discover, and navigate resources.</li>
-        <li><dfn>data resource</dfn> &mdash; a data-bearing resource such as a document, image, or structured data file.</li>
-        <li><dfn>contained resource</dfn> &mdash; A LWS resource, either a <a>container</a> or a <a>data resource</a>, that is referenced by one or more containers through a containment relationship.</li>
-        <li><dfn>root container</dfn> &mdash; a top-level container in an LWS storage. A root container has no parent and acts as the entry point for the storage hierarchy.</li>
-        <li><dfn>containment</dfn> &mdash; the relationship between a container and its member resources, expressed via the <code>items</code> property in container representations and the <code>rel="up"</code> link relation in HTTP headers.</li>
-        <li><dfn>linkset</dfn> &mdash; A separate resource associated with each LWS resource that contains the complete set of typed links (metadata) for that resource, as defined in [[RFC9264]]. The linkset is discovered via a rel="linkset" link relation and can be modified to manage resource relationships, including containment.</li>
-      </ul>
-
-      <p>
-        This specification defines <a>operations</a> on <a>served resources</a>, the resulting change of state, and a <a>response</a> intended to give the <a>requesting agent</a> requested infomation or inform them of the outcome of the <a>operation</a>.
-        An <dfn>operation</dfn> is any of the following actions that can be performed on a <a>served resource</a>:
-      </p>
-      <ul>
-        <li><dfn data-lt="creation">create resource</dfn> - </li>
-        <li><dfn data-lt="retrieval">read resource</dfn> - </li>
-        <li><dfn>update resource</dfn> - </li>
-        <li><dfn data-lt="deletion">delete resource</dfn> - </li>
-      </ul>
-
-      <p>
-        The folowing section will describe the semantics and <dfn>responses</dfn> of these operations but the following <dfn>core responses</dfn> apply to any operation:
-      </p>
-      <ul>
-        <li><dfn>success</dfn> - the operation is believed to have completed. This may be accompanied by a <dfn>resource representation</dfn> conveying the contents of a <a>served resource</a>. A <a>success</a> response is not defined for the <a>create resource</a> operation. See instead <a href="#dfn-created">created</a>.</li>
-        <li><dfn>not permitted</dfn></li>
-        <li><dfn>unknown requester</dfn></li>
-        <li><dfn>unknown error</dfn> - reserved for error conditions that arise that are not anticipated by the specification</li>
-      </ul>
-    </section>
+<section id="terminology">
+  <h2>Terminology</h2>
+  <p>
+    The terms "authorization server" and "client" are defined by the OAuth 2.0 Authorization Framework [[!RFC6749]].
+  </p>
+  <p>
+    The terms "end-user" and "issuer" are defined by OpenID Connect Core 1.0 [[!OPENID-CONNECT-CORE]].
+  </p>
+  <p>
+    This specification defines the following terms:
+  </p>
+  <ul>
+    <li><dfn>served resource</dfn> — A network-accessible entity exposed by an LWS REST server for interaction using this protocol.</li>
+    <li><dfn>requesting agent</dfn> — An entity that initiates a request to interact with a served resource.</li>
+    <li><dfn>resource manager</dfn> — An agent with permission to control access to a served resource.</li>
+    <li><dfn>authentication credential</dfn> — a security token that asserts claims about an agent or end-user. This token is secured with a cryptographic proof.
+      Examples of authentication credentials include assertions of identity such as OpenID Connect ID Tokens and SAML-based assertions as well as assertions of
+      capability such as a ZCAP.</li>
+    <li><dfn>authentication suite</dfn> — a defined validation mechanism for a concrete serialization of an authentication credential.</li>
+    <li><dfn>LWS resource</dfn> — An LWS Resource is an <a href="https://www.w3.org/TR/webarch/#def-information-resource">information resource</a> whose lifecycle is managed by the LWS storage.</li>
+    <li><dfn>container</dfn> — An LWS resource that maintains links to a set of contained resources whose lifecycle is governed by the same LWS server. Containers serve as organizational units enabling clients to group, discover, and navigate resources.</li>
+    <li><dfn>data resource</dfn> — a data-bearing resource such as a document, image, or structured data file.</li>
+    <li><dfn>contained resource</dfn> — An LWS resource, either a <a>container</a> or a <a>data resource</a>, that is referenced by one or more containers through a containment relationship.</li>
+    <li><dfn>root container</dfn> — a top-level container in an LWS storage. A root container has no parent and acts as the entry point for the storage hierarchy.</li>
+    <li><dfn>containment</dfn> — the relationship between a container and its member resources, expressed via the <code>items</code> property in container representations and the <code>rel="up"</code> link relation in HTTP headers.</li>
+    <li><dfn>linkset</dfn> — A separate resource associated with each LWS resource that contains the complete set of typed links (metadata) for that resource, as defined in [[RFC9264]]. The linkset is discovered via a rel="linkset" link relation and can be modified to manage resource relationships, including containment.</li>
+  </ul>
+  <p>
+    This specification defines <a>operations</a> on <a>served resources</a>, the resulting change of state, and a <a>response</a> intended to give the <a>requesting agent</a> requested information or inform them of the outcome of the <a>operation</a>.
+    An <dfn>operation</dfn> is any of the following actions that can be performed on a <a>served resource</a>:
+  </p>
+  <ul>
+    <li><dfn data-lt="creation">create resource</dfn> — Create a new resource in a container.</li>
+    <li><dfn data-lt="retrieval">read resource</dfn> — Retrieve the representation of an existing resource.</li>
+    <li><dfn>update resource</dfn> — Modify an existing resource.</li>
+    <li><dfn data-lt="deletion">delete resource</dfn> — Remove an existing resource.</li>
+  </ul>
+  <p>
+    The following section will describe the semantics and <dfn>responses</dfn> of these operations but the following <dfn>core responses</dfn> apply to any operation:
+  </p>
+  <ul>
+    <li><dfn>success</dfn> — the operation is believed to have completed. This may be accompanied by a <dfn>resource representation</dfn> conveying the contents of a <a>served resource</a>. A <a>success</a> response is not defined for the <a>create resource</a> operation. See instead <a href="#dfn-created">created</a>.</li>
+    <li><dfn>not permitted</dfn></li>
+    <li><dfn>unknown requester</dfn></li>
+    <li><dfn>unknown error</dfn> — reserved for error conditions that arise that are not anticipated by the specification.</li>
+  </ul>
+</section>
 
     <section id="authentication">
       <h2>Authentication</h2>

--- a/lws10-core/index.html
+++ b/lws10-core/index.html
@@ -199,6 +199,15 @@
     <li><dfn>root container</dfn> — a top-level container in an LWS storage. A root container has no parent and acts as the entry point for the storage hierarchy.</li>
     <li><dfn>containment</dfn> — the relationship between a container and its member resources, expressed via the <code>items</code> property in container representations and the <code>rel="up"</code> link relation in HTTP headers.</li>
     <li><dfn>linkset</dfn> — A separate resource associated with each LWS resource that contains the complete set of typed links (metadata) for that resource, as defined in [[RFC9264]]. The linkset is discovered via a rel="linkset" link relation and can be modified to manage resource relationships, including containment.</li>
+    <li><dfn>storage</dfn> — [TBD]</li>
+    <li><dfn>resource</dfn> — [TBD]</li>
+    <li><dfn>metadata</dfn> — [TBD]</li>
+    <li><dfn>agent</dfn> — [TBD]</li>
+    <li><dfn>controller</dfn> — [TBD]</li>
+    <li><dfn>service</dfn> — [TBD]</li>
+    <li><dfn>capability</dfn> — [TBD]</li>
+    <li><dfn>resource owner</dfn> — [TBD]</li>
+    <li><dfn>end user</dfn> — [TBD]</li>
   </ul>
   <p>
     This specification defines <a>operations</a> on <a>served resources</a>, the resulting change of state, and a <a>response</a> intended to give the <a>requesting agent</a> requested information or inform them of the outcome of the <a>operation</a>.


### PR DESCRIPTION
fix spelling and formatting


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/pull/122.html" title="Last updated on Apr 6, 2026, 6:11 PM UTC (2bee0ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/122/1c02875...2bee0ac.html" title="Last updated on Apr 6, 2026, 6:11 PM UTC (2bee0ac)">Diff</a>