### PR TITLE
feat(notifications): Introduce the LWS notifications specification as an optional service

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ To see the most recent HTML rendered version of the specification from this repo
 - [`authn-saml`](lws10-authn-saml/): SAML 2.0 Authentication Suite
 - [`authn-ssi-cid`](lws10-authn-ssi-cid): Self-signed Controlled Identifier Authentication Suite
 - [`authn-ssi-did-key`](lws10-authn-ssi-did-key): Self-signed `did:key` Authentication Suite
+- [`notifications`](lws10-notifications/): Notifications
 
 
 ## Contribution Guidelines:

--- a/lws10-core/Discovery.html
+++ b/lws10-core/Discovery.html
@@ -125,7 +125,8 @@
   ],
   "service": [{
     "type": "NotificationService",
-    "serviceEndpoint": "https://storage.example/notification/api"
+    "serviceEndpoint": "https://storage.example/notification/api",
+    "subscriptionType": ["WebhookSubscription", "WebSocketSubscription", "EventSourceSubscription"]
   }, {
     "type": "TypeIndexService",
     "serviceEndpoint": "https://storage.example/types/api"

--- a/lws10-core/Unstable-Features/Notifications.md
+++ b/lws10-core/Unstable-Features/Notifications.md
@@ -1,2 +1,9 @@
-this left intentionally blank
+# Notifications
 
+The [LWS Notifications](../../lws10-notifications/index.html) specification extends the Linked Web Storage (LWS) protocol with a mechanism for clients to receive timely updates about changes to resources. Three notification channels are defined:
+
+- **Server-Sent Events** — streaming updates over an EventSource connection
+- **WebSocket** — real-time bidirectional notification channel
+- **Webhooks** — server-to-server push notifications with HTTP Message Signatures
+
+All channels share a common notification data model based on Activity Streams and are discoverable via the storage description resource.

--- a/lws10-notifications/index.html
+++ b/lws10-notifications/index.html
@@ -1,0 +1,987 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>LWS Notifications</title>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+    <script class='remove'>
+      // See https://respec.org/docs/ for how to configure ReSpec
+      var respecConfig = {
+        specStatus: "ED",
+        shortName: "lws-notifications",
+        editors: [{
+          name: "Jesse Wright",
+          w3cid: "132252",
+          company: "University of Oxford",
+          companyURL: "https://www.ox.ac.uk/"
+        }],
+        authors: [{
+          name: "Laurens Debackere"
+        }],
+        github: "w3c/lws-protocol",
+        xref: ["web-platform"],
+        group: "lws",
+        maxTocLevel: 3,
+        localBiblio: {
+          "LWS-PROTOCOL": {
+            title: "LWS Protocol",
+            href: "https://www.w3.org/TR/lws-core/",
+            publisher: "W3C",
+            status: "FPWD",
+          },
+          "RFC9421": {
+            title: "HTTP Message Signatures",
+            href: "https://www.rfc-editor.org/rfc/rfc9421",
+            publisher: "IETF",
+            status: "Proposed Standard",
+          },
+          "RFC9530": {
+            title: "Digest Fields",
+            href: "https://www.rfc-editor.org/rfc/rfc9530",
+            publisher: "IETF",
+            status: "Proposed Standard",
+          },
+        },
+      };
+    </script>
+  </head>
+  <body>
+    <section id="abstract">
+      <p>
+        This document extends the Linked Web Storage (LWS) protocol with a mechanism for clients
+        to receive timely updates about changes to resources. Three notification channels are
+        defined: Server-Sent Events, WebSocket, and Webhooks. All channels share a common
+        notification data model and are discoverable via the storage description resource.
+      </p>
+    </section>
+    <section id="sotd">
+      <p>
+        This is an unofficial proposal.
+      </p>
+    </section>
+
+    <section id="introduction">
+      <h2>Introduction</h2>
+
+      <p>
+        The [[!LWS-PROTOCOL|Linked Web Storage]] protocol defines a resource-centric storage
+        system built on HTTP. While the core protocol supports creating, reading, updating, and
+        deleting resources, it does not define a mechanism for clients to learn about changes
+        without polling.
+      </p>
+
+      <p>
+        This specification extends LWS with a <a>notification</a> mechanism that allows clients
+        to subscribe to resource changes and receive updates through one of three channels:
+      </p>
+
+      <ul>
+        <li>
+          <strong>Server-Sent Events (SSE)</strong>: A client opens a persistent HTTP connection
+          and receives real-time change events as a stream of server-sent events.
+        </li>
+        <li>
+          <strong>WebSocket</strong>: A client opens a persistent WebSocket connection and receives
+          real-time change events as WebSocket messages.
+        </li>
+        <li>
+          <strong>Webhooks</strong>: A server-to-server mechanism whereby the LWS storage server
+          delivers change events to a registered endpoint via HTTP POST.
+        </li>
+      </ul>
+
+      <p>
+        All three channels share a common notification envelope and are discoverable
+        via the storage description resource.
+      </p>
+    </section>
+
+    <section id="conformance"></section>
+
+    <section id="terminology">
+      <h2>Terminology</h2>
+
+      <p>
+        The terms "storage description resource", "resource manager", and "requesting agent" are
+        defined by [[!LWS-PROTOCOL]].
+      </p>
+
+      <p>
+        This specification defines the following additional terms:
+      </p>
+
+      <ul>
+        <li>
+          <dfn>Notification</dfn> &mdash; a message describing an event that has occurred on
+          a resource.
+        </li>
+        <li>
+          <dfn>Subscription</dfn> &mdash; a registration expressing interest in receiving
+          notifications for a given resource or set of resources.
+        </li>
+        <li>
+          <dfn>Capability URL</dfn> &mdash; a URL that encodes a subscription scope and
+          serves as the credential for establishing a notification connection.
+        </li>
+        <li>
+          <dfn>Webhook Endpoint</dfn> &mdash; a URL controlled by a subscribing party to
+          which the server delivers notifications via HTTP.
+        </li>
+      </ul>
+    </section>
+
+    <section id="discovery">
+      <h2>Discovery</h2>
+
+      <p>
+        A client discovers notification support through the storage description resource.
+        A storage that supports notifications MUST advertise a service object in its
+        <code>service</code> array with <code>type</code> equal to
+        <code>NotificationService</code>.
+      </p>
+
+      <p>
+        The service object MUST include a <code>serviceEndpoint</code> property whose value
+        is the URI of the subscription endpoint. The service object MUST include a
+        <code>subscriptionType</code> property whose value is an array of strings, each
+        identifying a supported <a>subscription</a> type.
+      </p>
+
+      <p>
+        Additional properties MAY be present on the service object.
+      </p>
+
+      <pre class="example" title="Storage description with notification service">
+{
+  "@context": ["https://www.w3.org/ns/lws/v1"],
+  "id": "https://storage.example/",
+  "type": "Storage",
+  "service": [{
+    "type": "NotificationService",
+    "serviceEndpoint": "https://notification.example/subscriptions",
+    "subscriptionType": [
+      "WebhookSubscription",
+      "WebSocketSubscription",
+      "EventSourceSubscription"
+    ]
+  }]
+}
+      </pre>
+
+      <p class="note">
+        A server is not required to support all subscription types. The
+        <code>subscriptionType</code> array advertises exactly which types are available.
+      </p>
+    </section>
+
+    <section id="notification-envelope">
+      <h2>Notification Envelope</h2>
+
+      <p>
+        A <a>notification</a> is represented as a JSON-LD document with a
+        <code>Notification</code> type. The envelope carries metadata about the delivery
+        context and wraps an Activity Streams 2.0 [[ACTIVITYSTREAMS-CORE]] [[ACTIVITYSTREAMS-VOCABULARY]]
+        activity describing the event.
+      </p>
+
+      <section id="envelope-properties">
+        <h3>Envelope Properties</h3>
+
+        <p>
+          A notification envelope has the following properties:
+        </p>
+
+        <ul>
+          <li>
+            <code>type</code> &mdash; REQUIRED. The value MUST be the string
+            <code>Notification</code>.
+          </li>
+          <li>
+            <code>phase</code> &mdash; REQUIRED. A string indicating the lifecycle phase
+            of the notification. The value MUST be <code>post-commit</code>. Other values
+            MAY be defined by future specifications.
+          </li>
+          <li>
+            <code>storage</code> &mdash; REQUIRED. A URI identifying the LWS storage with
+            which the notification is associated.
+          </li>
+          <li>
+            <code>activity</code> &mdash; REQUIRED. A JSON object or an array of JSON objects,
+            each conforming to the Activity Streams 2.0 data model, describing the event or
+            events that occurred. See <a href="#activity-properties"></a>.
+          </li>
+        </ul>
+
+        <pre class="example" title="Notification envelope">
+{
+  "@context": [
+    "https://www.w3.org/ns/lws/v1",
+    "https://www.w3.org/ns/activitystreams"
+  ],
+  "type": "Notification",
+  "phase": "post-commit",
+  "storage": "https://storage.example/",
+  "activity": {
+    "id": "ec4dcc48-6581-4232-81c9-584525a98693",
+    "type": ["Delete"],
+    "object": {
+      "id": "https://storage.example/alice/notes/shopping.txt",
+      "type": "DataResource"
+    },
+    "origin": "https://storage.example/alice/notes/",
+    "published": "2026-03-26T10:30:00Z"
+  }
+}
+        </pre>
+      </section>
+
+      <section id="activity-properties">
+        <h3>Activity Properties</h3>
+
+        <p>
+          The <code>activity</code> object MUST conform to the Activity Streams 2.0 data model
+          and MUST include the following properties:
+        </p>
+
+        <ul>
+          <li>
+            <code>id</code> &mdash; REQUIRED. A string uniquely identifying the activity.
+          </li>
+          <li>
+            <code>type</code> &mdash; REQUIRED. An array containing at least one Activity
+            Streams 2.0 activity type.
+          </li>
+          <li>
+            <code>object</code> &mdash; REQUIRED. A JSON object identifying the resource
+            that the notification is about. The object MUST include an <code>id</code>
+            property with the resource URI and a <code>type</code> property.
+          </li>
+          <li>
+            <code>published</code> &mdash; REQUIRED. A datetime value indicating when the
+            activity occurred.
+          </li>
+        </ul>
+
+        <p>
+          The following properties are OPTIONAL:
+        </p>
+
+        <ul>
+          <li>
+            <code>actor</code> &mdash; the agent that performed the action.
+          </li>
+          <li>
+            <code>target</code> &mdash; a URI identifying the container into which the
+            resource was added. Used with <code>Create</code> activities.
+          </li>
+          <li>
+            <code>origin</code> &mdash; a URI identifying the container from which the
+            resource was removed. Used with <code>Delete</code> activities.
+          </li>
+        </ul>
+      </section>
+
+      <section id="activity-types">
+        <h3>Activity Types</h3>
+
+        <p>
+          A server MUST support the following Activity Streams 2.0 activity types to
+          indicate LWS resource changes:
+        </p>
+
+        <ul>
+          <li>
+            <code>Create</code> &mdash; a new resource was created in a container. The
+            <code>target</code> field indicates the container to which the resource was added.
+          </li>
+          <li>
+            <code>Update</code> &mdash; an existing resource's content or metadata was modified.
+          </li>
+          <li>
+            <code>Delete</code> &mdash; a resource was removed. The <code>origin</code> field
+            indicates the container from which the resource was removed.
+          </li>
+        </ul>
+
+        <p>
+          Other activity types MAY also be supported.
+        </p>
+      </section>
+
+      <section id="batching">
+        <h3>Batching Notifications</h3>
+
+        <p>
+          A server MAY combine multiple activities into a single notification envelope by
+          providing an array of activity objects as the value of the <code>activity</code>
+          property.
+        </p>
+
+        <pre class="example" title="Batched notification">
+{
+  "@context": [
+    "https://www.w3.org/ns/lws/v1",
+    "https://www.w3.org/ns/activitystreams"
+  ],
+  "type": "Notification",
+  "phase": "post-commit",
+  "storage": "https://storage.example/",
+  "activity": [
+    {
+      "id": "a1b2c3d4-5678-9abc-def0-1234567890ab",
+      "type": ["Create"],
+      "object": {
+        "id": "https://storage.example/alice/notes/meeting.txt",
+        "type": "DataResource"
+      },
+      "target": "https://storage.example/alice/notes/",
+      "published": "2026-03-26T10:30:00Z"
+    },
+    {
+      "id": "b2c3d4e5-6789-abcd-ef01-234567890abc",
+      "type": ["Update"],
+      "object": {
+        "id": "https://storage.example/alice/profile",
+        "type": "DataResource"
+      },
+      "published": "2026-03-26T10:30:01Z"
+    }
+  ]
+}
+        </pre>
+      </section>
+    </section>
+
+    <section id="subscriptions">
+      <h2>Subscriptions</h2>
+
+      <p>
+        To receive notifications, a client creates a <a>subscription</a> by sending an
+        authenticated <code>POST</code> request to the <code>serviceEndpoint</code> of the
+        <code>NotificationService</code>. The request body MUST conform to the
+        <code>application/lws+json</code> media type.
+      </p>
+
+      <section id="subscription-request">
+        <h3>Subscription Request</h3>
+
+        <p>
+          A subscription request MUST contain the following fields:
+        </p>
+
+        <ul>
+          <li>
+            <code>type</code> &mdash; REQUIRED. A string identifying the subscription type.
+            The value MUST be one of the types listed in the <code>subscriptionType</code>
+            array of the <code>NotificationService</code>.
+          </li>
+          <li>
+            <code>phase</code> &mdash; REQUIRED. A string indicating the lifecycle phase for
+            which notifications are requested. The value MUST be <code>post-commit</code>.
+            Other values MAY be defined by future specifications.
+          </li>
+          <li>
+            <code>topic</code> &mdash; REQUIRED. An array of URIs identifying the resources
+            included in the subscription. A subscription to a container includes notifications
+            for all resources contained in that container.
+          </li>
+        </ul>
+
+        <p>
+          A subscription request MAY contain additional fields as required by the specific
+          subscription type.
+        </p>
+
+        <pre class="example" title="Subscription request">
+POST /subscriptions HTTP/2
+Host: notification.example
+Authorization: Bearer &lt;access-token&gt;
+Content-Type: application/lws+json
+
+{
+  "@context": ["https://www.w3.org/ns/lws/v1"],
+  "type": "EventSourceSubscription",
+  "phase": "post-commit",
+  "topic": [
+    "https://storage.example/alice/notes/",
+    "https://storage.example/alice/profile"
+  ]
+}
+        </pre>
+
+        <p>
+          A server MUST enforce resource authorization. If an agent does not have the
+          equivalent of read access to all listed resources, a server MUST reject the
+          subscription request.
+        </p>
+      </section>
+
+      <section id="subscription-response">
+        <h3>Subscription Response</h3>
+
+        <p>
+          The response to a successful subscription creation request MUST conform to the
+          <code>application/lws+json</code> media type and MUST contain the following fields:
+        </p>
+
+        <ul>
+          <li>
+            <code>type</code> &mdash; REQUIRED. A string equal to the subscription type from
+            the request.
+          </li>
+          <li>
+            <code>subscription</code> &mdash; REQUIRED. A URL representing the subscription.
+          </li>
+        </ul>
+      </section>
+    </section>
+
+    <section id="websocket-notifications">
+      <h2>WebSocket Notifications</h2>
+
+      <p>
+        The WebSocket notification channel allows a client to receive notifications over a
+        persistent WebSocket connection.
+      </p>
+
+      <section id="websocket-subscription">
+        <h3>Creating a WebSocket Subscription</h3>
+
+        <p>
+          When a client creates a WebSocket notification subscription, the subscription body
+          MUST include a <code>type</code> field equal to <code>WebSocketSubscription</code>.
+        </p>
+
+        <p>
+          A successful response body has these additional requirements:
+        </p>
+
+        <ul>
+          <li>
+            <code>type</code> &mdash; the value of this property MUST be a string equal to
+            <code>WebSocketSubscription</code>.
+          </li>
+          <li>
+            <code>subscription</code> &mdash; the value of this property MUST be a
+            <a>capability URL</a> that can be used by the WebSocket API.
+          </li>
+        </ul>
+
+        <pre class="example" title="WebSocket subscription response">
+{
+  "@context": ["https://www.w3.org/ns/lws/v1"],
+  "type": "WebSocketSubscription",
+  "subscription": "wss://notification.example/ws/1c2d3e4f5a6b"
+}
+        </pre>
+      </section>
+
+      <section id="websocket-connection">
+        <h3>Establishing a WebSocket Connection</h3>
+
+        <p>
+          After obtaining a <a>capability URL</a>, the client opens a WebSocket connection to
+          that URL. The server sends notification envelopes as WebSocket text messages, serialized
+          as JSON.
+        </p>
+
+        <pre class="example" title="WebSocket client">
+const ws = new WebSocket(capabilityUrl);
+ws.onmessage = (event) => {
+  const notification = JSON.parse(event.data);
+  // handle notification
+};
+        </pre>
+
+        <p>
+          The lifecycle of a WebSocket <a>subscription</a> is tied to the connection. When the
+          WebSocket connection is closed, the subscription is terminated.
+        </p>
+      </section>
+    </section>
+
+    <section id="eventsource-notifications">
+      <h2>Server-Sent Event Notifications</h2>
+
+      <p>
+        The Server-Sent Event (SSE) notification channel allows a client to receive
+        notifications over a persistent HTTP connection using the EventSource API.
+      </p>
+
+      <section id="eventsource-subscription">
+        <h3>Creating an EventSource Subscription</h3>
+
+        <p>
+          When a client creates an EventSource notification subscription, the subscription body
+          MUST include a <code>type</code> field equal to <code>EventSourceSubscription</code>.
+        </p>
+
+        <p>
+          A successful response body has these additional requirements:
+        </p>
+
+        <ul>
+          <li>
+            <code>type</code> &mdash; the value of this property MUST be a string equal to
+            <code>EventSourceSubscription</code>.
+          </li>
+          <li>
+            <code>subscription</code> &mdash; the value of this property MUST be a
+            <a>capability URL</a> that can be used by the EventSource API.
+          </li>
+        </ul>
+
+        <pre class="example" title="EventSource subscription response">
+{
+  "@context": ["https://www.w3.org/ns/lws/v1"],
+  "type": "EventSourceSubscription",
+  "subscription": "https://notification.example/sse/0d8b4c2e1a3f"
+}
+        </pre>
+      </section>
+
+      <section id="eventsource-connection">
+        <h3>Establishing an EventSource Connection</h3>
+
+        <p>
+          After obtaining a <a>capability URL</a>, the client establishes a persistent SSE
+          connection to that URL. The server responds with <code>Content-Type:
+          text/event-stream</code> and pushes notification envelopes as events. Each event
+          MUST include an <code>id</code> field to support reconnection via the
+          <code>Last-Event-ID</code> header.
+        </p>
+
+        <pre class="example" title="EventSource client">
+const source = new EventSource(capabilityUrl);
+source.onmessage = (event) => {
+  const notification = JSON.parse(event.data);
+  // handle notification
+};
+        </pre>
+
+        <p>
+          The lifecycle of an EventSource <a>subscription</a> is tied to the connection. When
+          the connection is closed, the subscription is terminated.
+        </p>
+      </section>
+    </section>
+
+    <section id="webhook-notifications">
+      <h2>Webhook Notifications</h2>
+
+      <p>
+        Webhooks enable server-to-server notification delivery. After a webhook subscription is
+        created, the LWS storage server delivers notifications to the registered
+        <a>webhook endpoint</a> when relevant changes occur.
+      </p>
+
+      <section id="webhook-subscription">
+        <h3>Creating a Webhook Subscription</h3>
+
+        <p>
+          When a client creates a webhook notification subscription, the subscription body MUST
+          include a <code>type</code> field equal to <code>WebhookSubscription</code>. In
+          addition, a server MUST support the following fields:
+        </p>
+
+        <ul>
+          <li>
+            <code>inbox</code> &mdash; REQUIRED. The URI of the endpoint to which notification
+            messages are sent.
+          </li>
+          <li>
+            <code>expires</code> &mdash; OPTIONAL. A datetime value indicating when the
+            subscription expires.
+          </li>
+        </ul>
+
+        <pre class="example" title="Webhook subscription request">
+POST /subscriptions HTTP/2
+Host: notification.example
+Authorization: Bearer &lt;access-token&gt;
+Content-Type: application/lws+json
+
+{
+  "@context": ["https://www.w3.org/ns/lws/v1"],
+  "type": "WebhookSubscription",
+  "phase": "post-commit",
+  "topic": [
+    "https://storage.example/alice/notes/",
+    "https://storage.example/alice/profile"
+  ],
+  "inbox": "https://receiver.example/hooks/lws",
+  "expires": "2026-06-09T12:00:00Z"
+}
+        </pre>
+
+        <p>
+          A successful response body has these additional requirements:
+        </p>
+
+        <ul>
+          <li>
+            <code>type</code> &mdash; the value of this property MUST be a string equal to
+            <code>WebhookSubscription</code>.
+          </li>
+          <li>
+            <code>subscription</code> &mdash; a URL that can be used to manage the lifecycle of
+            the subscription.
+          </li>
+          <li>
+            <code>expires</code> &mdash; OPTIONAL. A datetime value indicating when the
+            subscription expires.
+          </li>
+        </ul>
+
+        <pre class="example" title="Webhook subscription response">
+HTTP/2 200 OK
+Content-Type: application/lws+json
+Location: https://notification.example/subscriptions/9e8d7c6b5a4f
+
+{
+  "@context": ["https://www.w3.org/ns/lws/v1"],
+  "type": "WebhookSubscription",
+  "subscription": "https://notification.example/subscriptions/9e8d7c6b5a4f",
+  "expires": "2026-06-09T12:00:00Z"
+}
+        </pre>
+      </section>
+
+      <section id="webhook-authentication">
+        <h3>Webhook Authentication</h3>
+
+        <p>
+          When a server delivers a notification to a <a>webhook endpoint</a>, the receiving
+          party needs to verify that the request is authentic.
+        </p>
+
+        <p>
+          A server SHOULD sign each outbound request using HTTP Message Signatures
+          [[!RFC9421]]. When a <a>webhook endpoint</a> receives a signed message, it MUST verify
+          the signature using the notification server's public key, discoverable via the storage
+          description resource.
+        </p>
+
+        <p>
+          A server that supports HTTP Message Signatures MUST include the public portion of
+          its signing key in the storage description resource using a
+          <code>verificationMethod</code> property.
+        </p>
+
+        <pre class="example" title="Storage description with verification method">
+{
+  "@context": ["https://www.w3.org/ns/lws/v1"],
+  "id": "https://storage.example/",
+  "type": "Storage",
+  "verificationMethod": [{
+    "id": "https://storage.example/#key-20260320",
+    "type": "JsonWebKey",
+    "controller": "https://storage.example/",
+    "publicKeyJwk": {
+      "kid": "key-20260320",
+      "kty": "EC",
+      "crv": "P-256",
+      "alg": "ES256",
+      "x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+      "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"
+    }
+  }],
+  "service": [{
+    "type": "NotificationService",
+    "serviceEndpoint": "https://notification.example/subscriptions",
+    "subscriptionType": ["WebhookSubscription"]
+  }]
+}
+        </pre>
+
+        <section id="signature-requirements">
+          <h4>Signature Requirements</h4>
+
+          <p>
+            A server that signs webhook delivery requests MUST include at least the following
+            components in the signature base:
+          </p>
+
+          <ul>
+            <li><code>@method</code> &mdash; the HTTP method of the request (always POST).</li>
+            <li><code>@scheme</code> &mdash; prevents downgrade from https to http.</li>
+            <li>
+              <code>@authority</code> &mdash; the host of the <a>webhook endpoint</a>,
+              preventing delivery to an unintended endpoint.
+            </li>
+            <li>
+              <code>@path</code> &mdash; the path component of the <a>webhook endpoint</a> URL.
+            </li>
+            <li>
+              <code>content-type</code> &mdash; the media type of the request body.
+            </li>
+            <li>
+              <code>content-digest</code> &mdash; a digest of the request body, computed
+              according to [[!RFC9530]].
+            </li>
+          </ul>
+
+          <p>
+            The <code>Signature-Input</code> field MUST include the <code>created</code> and
+            <code>keyid</code> parameters. The <code>keyid</code> value MUST correspond to
+            the <code>id</code> of a key in the <code>verificationMethod</code> array of the
+            storage description resource.
+          </p>
+        </section>
+
+        <section id="signature-verification">
+          <h4>Signature Verification</h4>
+
+          <p>
+            To verify a webhook signature, a receiver MUST perform the following steps:
+          </p>
+
+          <ol>
+            <li>
+              Extract the <code>keyid</code> value from the <code>Signature-Input</code>
+              field. The <code>keyid</code> value MUST be a URL with a fragment component.
+            </li>
+            <li>
+              Remove the fragment component from the <code>keyid</code> URL. The resulting
+              URL is the storage identifier.
+            </li>
+            <li>
+              Dereference the storage identifier to retrieve the storage description resource.
+              The <code>id</code> property of the top-level document map MUST match the
+              storage identifier.
+            </li>
+            <li>
+              Find the object in the <code>verificationMethod</code> array whose
+              <code>id</code> property matches either the full <code>keyid</code> URL or the
+              fragment component of the <code>keyid</code> URL.
+            </li>
+            <li>
+              Verify the HTTP Message Signature using the located verification method.
+            </li>
+          </ol>
+        </section>
+      </section>
+
+      <section id="webhook-subscription-management">
+        <h3>Subscription Management</h3>
+
+        <p>
+          The value of the <code>serviceEndpoint</code> property for a
+          <code>NotificationService</code> that supports <code>WebhookSubscription</code>
+          MUST be a URL that supports <code>GET</code> operations to list an agent's active
+          webhook subscriptions. The resulting serialization MUST conform to the requirements
+          for LWS Containers [[!LWS-PROTOCOL]]. The response SHOULD support LWS Paging.
+        </p>
+
+        <p>
+          Each subscription resource listed in this container MUST support <code>GET</code>
+          and <code>DELETE</code> operations. A <code>GET</code> request returns the current
+          state of the subscription. A <code>DELETE</code> request cancels the subscription.
+        </p>
+      </section>
+
+      <section id="webhook-delivery">
+        <h3>Notification Delivery</h3>
+
+        <p>
+          The server sends an HTTP <code>POST</code> request to the registered
+          <a>webhook endpoint</a> with the notification envelope as the request body. The
+          request body MUST conform to the <code>application/lws+json</code> media type.
+        </p>
+
+        <ul>
+          <li>
+            <strong>Acknowledgment</strong>: A 2xx response indicates successful receipt.
+          </li>
+          <li>
+            <strong>Retry</strong>: On failure, the server MAY retry delivery.
+          </li>
+          <li>
+            <strong>Expiration</strong>: After repeated failures, the server MAY deactivate
+            the subscription.
+          </li>
+        </ul>
+      </section>
+    </section>
+
+    <section id="security-considerations" class="informative">
+      <h2>Security Considerations</h2>
+
+      <ul>
+        <li>
+          <strong>Token Leakage</strong>: <a>Capability URLs</a> used with SSE and WebSocket
+          channels might be visible in server logs and a browser's history. Mitigations include
+          using short-lived and single-use URLs.
+        </li>
+        <li>
+          <strong>Webhook Verification</strong>: Without proper authentication on webhook
+          deliveries, an attacker could spoof notifications. Webhook receivers are strongly
+          encouraged to validate HTTP Message Signatures on all incoming notification requests
+          using the public key published in the associated storage description resource.
+        </li>
+        <li>
+          <strong>Subscription Abuse</strong>: Rate limiting and endpoint verification are
+          suggested to prevent abuse of the subscription mechanism.
+        </li>
+        <li>
+          <strong>Signature Replay</strong>: A signed webhook request could be captured and
+          replayed by an attacker. Webhook receivers are encouraged to check the
+          <code>created</code> parameter in the <code>Signature-Input</code> field and reject
+          signatures whose timestamp falls outside a reasonable clock-skew window.
+        </li>
+        <li>
+          <strong>Information Disclosure</strong>: Notifications may reveal the existence or
+          modification patterns of resources. It is strongly recommended that access control on
+          subscriptions be consistent with access control on the underlying resources.
+        </li>
+        <li>
+          <strong>Phase Security</strong>: The <code>phase</code> property is defined with only
+          the <code>post-commit</code> value in this specification. Future specifications
+          defining additional lifecycle phases (such as pre-commit interception) MUST define
+          their own security requirements, particularly for synchronous request-response
+          patterns where a subscriber can influence resource persistence.
+        </li>
+      </ul>
+    </section>
+
+    <section id="privacy-considerations" class="informative">
+      <h2>Privacy Considerations</h2>
+
+      <ul>
+        <li>
+          <strong>Activity Tracking</strong>: Notifications inherently reveal when resources
+          change. Subscribers SHOULD only receive notifications for resources they are
+          authorized to access.
+        </li>
+        <li>
+          <strong>Actor Disclosure</strong>: Including the <code>actor</code> property in
+          notifications reveals who made changes. This may be inappropriate in some contexts.
+          The <code>actor</code> property SHOULD be omitted by default. Servers MAY make
+          its inclusion configurable.
+        </li>
+        <li>
+          <strong>Timing Analysis</strong>: The timing of notifications can reveal usage
+          patterns even when content is not disclosed.
+        </li>
+      </ul>
+    </section>
+
+    <section id="vocabulary">
+      <h2>Vocabulary</h2>
+
+      <p>
+        This document defines the following terms in the
+        <code>https://www.w3.org/ns/lws#</code> namespace:
+      </p>
+
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>Term</th>
+            <th>URI</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>Notification</code></td>
+            <td><code>lws:Notification</code></td>
+            <td>Notification envelope type</td>
+          </tr>
+          <tr>
+            <td><code>NotificationService</code></td>
+            <td><code>lws:NotificationService</code></td>
+            <td>Service type for notification discovery</td>
+          </tr>
+          <tr>
+            <td><code>WebSocketSubscription</code></td>
+            <td><code>lws:WebSocketSubscription</code></td>
+            <td>WebSocket subscription type</td>
+          </tr>
+          <tr>
+            <td><code>EventSourceSubscription</code></td>
+            <td><code>lws:EventSourceSubscription</code></td>
+            <td>Server-Sent Event subscription type</td>
+          </tr>
+          <tr>
+            <td><code>WebhookSubscription</code></td>
+            <td><code>lws:WebhookSubscription</code></td>
+            <td>Webhook subscription type</td>
+          </tr>
+          <tr>
+            <td><code>subscriptionType</code></td>
+            <td><code>lws:subscriptionType</code></td>
+            <td>Supported subscription types on a notification service</td>
+          </tr>
+          <tr>
+            <td><code>subscription</code></td>
+            <td><code>lws:subscription</code></td>
+            <td>URL of the subscription resource</td>
+          </tr>
+          <tr>
+            <td><code>phase</code></td>
+            <td><code>lws:phase</code></td>
+            <td>Lifecycle phase of the notification</td>
+          </tr>
+          <tr>
+            <td><code>activity</code></td>
+            <td><code>lws:activity</code></td>
+            <td>Activity Streams 2.0 payload within a notification</td>
+          </tr>
+          <tr>
+            <td><code>topic</code></td>
+            <td><code>lws:topic</code></td>
+            <td>Array of resource URIs included in a subscription</td>
+          </tr>
+          <tr>
+            <td><code>storage</code></td>
+            <td><code>lws:storage</code></td>
+            <td>URI identifying the LWS storage</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>
+        This document uses the following terms from external vocabularies, which should be
+        added to the LWS JSON-LD context:
+      </p>
+
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>Term</th>
+            <th>URI</th>
+            <th>Source</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>verificationMethod</code></td>
+            <td><code>https://w3id.org/security#verificationMethod</code></td>
+            <td>Security Vocabulary</td>
+          </tr>
+          <tr>
+            <td><code>controller</code></td>
+            <td><code>https://w3id.org/security#controller</code></td>
+            <td>Security Vocabulary</td>
+          </tr>
+          <tr>
+            <td><code>publicKeyJwk</code></td>
+            <td><code>https://w3id.org/security#publicKeyJwk</code></td>
+            <td>Security Vocabulary</td>
+          </tr>
+          <tr>
+            <td><code>inbox</code></td>
+            <td><code>http://www.w3.org/ns/ldp#inbox</code></td>
+            <td>Linked Data Platform</td>
+          </tr>
+          <tr>
+            <td><code>expires</code></td>
+            <td><code>https://schema.org/expires</code></td>
+            <td>Schema.org</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </body>
+</html>

--- a/lws10-notifications/index.html
+++ b/lws10-notifications/index.html
@@ -202,6 +202,13 @@
         <h3>Envelope Properties</h3>
 
         <p>
+          The notification envelope carries metadata about the delivery context alongside
+          the activity payload. This includes the originating storage, the subscription
+          type, and an optional phase indicating at which point in the resource lifecycle
+          the notification was emitted.
+        </p>
+
+        <p>
           A notification envelope has the following properties:
         </p>
 
@@ -211,9 +218,10 @@
             <code>Notification</code>.
           </li>
           <li>
-            <code>phase</code> &mdash; OPTIONAL. A string indicating the lifecycle phase
-            of the notification. This specification defines the value
-            <code>PostCommit</code>.
+            <code>phase</code> &mdash; OPTIONAL. A string indicating at which point in
+            the resource lifecycle the notification was emitted. This specification defines
+            the value <code>PostCommit</code>, which indicates that the described change
+            has already been persisted.
           </li>
           <li>
             <code>storage</code> &mdash; REQUIRED. A URI identifying the LWS storage with

--- a/lws10-notifications/index.html
+++ b/lws10-notifications/index.html
@@ -41,6 +41,12 @@
             publisher: "IETF",
             status: "Proposed Standard",
           },
+          "CID-1.0": {
+            title: "Controlled Identifiers 1.0",
+            href: "https://www.w3.org/TR/cid-1.0/",
+            publisher: "W3C",
+            status: "REC",
+          },
         },
       };
     </script>
@@ -102,8 +108,13 @@
       <h2>Terminology</h2>
 
       <p>
-        The terms "storage description resource", "resource manager", and "requesting agent" are
-        defined by [[!LWS-PROTOCOL]].
+        The terms "storage description resource", "resource manager", "requesting agent",
+        "container", and "data resource" are defined by [[!LWS-PROTOCOL]].
+      </p>
+
+      <p>
+        The terms "controlled identifier document", "verification method", and "verification
+        relationship" are defined by Controlled Identifiers 1.0 [[!CID-1.0]].
       </p>
 
       <p>
@@ -120,11 +131,15 @@
           notifications for a given resource or set of resources.
         </li>
         <li>
+          <dfn>Subscriber</dfn> &mdash; the agent that creates a <a>subscription</a> and
+          receives the resulting notifications.
+        </li>
+        <li>
           <dfn>Capability URL</dfn> &mdash; a URL that encodes a subscription scope and
           serves as the credential for establishing a notification connection.
         </li>
         <li>
-          <dfn>Webhook Endpoint</dfn> &mdash; a URL controlled by a subscribing party to
+          <dfn>Webhook Endpoint</dfn> &mdash; a URL controlled by a <a>subscriber</a> to
           which the server delivers notifications via HTTP.
         </li>
       </ul>
@@ -134,10 +149,9 @@
       <h2>Discovery</h2>
 
       <p>
-        A client discovers notification support through the storage description resource.
-        A storage that supports notifications MUST advertise a service object in its
-        <code>service</code> array with <code>type</code> equal to
-        <code>NotificationService</code>.
+        A storage MAY support notifications. A storage that supports notifications MUST
+        advertise a service object in the <code>service</code> array of its storage description
+        resource with <code>type</code> equal to <code>NotificationService</code>.
       </p>
 
       <p>
@@ -197,9 +211,9 @@
             <code>Notification</code>.
           </li>
           <li>
-            <code>phase</code> &mdash; REQUIRED. A string indicating the lifecycle phase
-            of the notification. The value MUST be <code>post-commit</code>. Other values
-            MAY be defined by future specifications.
+            <code>phase</code> &mdash; OPTIONAL. A string indicating the lifecycle phase
+            of the notification. This specification defines the value
+            <code>PostCommit</code>.
           </li>
           <li>
             <code>storage</code> &mdash; REQUIRED. A URI identifying the LWS storage with
@@ -219,14 +233,14 @@
     "https://www.w3.org/ns/activitystreams"
   ],
   "type": "Notification",
-  "phase": "post-commit",
+  "phase": "PostCommit",
   "storage": "https://storage.example/",
   "activity": {
     "id": "ec4dcc48-6581-4232-81c9-584525a98693",
     "type": ["Delete"],
     "object": {
       "id": "https://storage.example/alice/notes/shopping.txt",
-      "type": "DataResource"
+      "type": ["DataResource"]
     },
     "origin": "https://storage.example/alice/notes/",
     "published": "2026-03-26T10:30:00Z"
@@ -239,8 +253,8 @@
         <h3>Activity Properties</h3>
 
         <p>
-          The <code>activity</code> object MUST conform to the Activity Streams 2.0 data model
-          and MUST include the following properties:
+          Each activity object within the <code>activity</code> property MUST conform to the
+          Activity Streams 2.0 data model and MUST include the following properties:
         </p>
 
         <ul>
@@ -248,17 +262,28 @@
             <code>id</code> &mdash; REQUIRED. A string uniquely identifying the activity.
           </li>
           <li>
-            <code>type</code> &mdash; REQUIRED. An array containing at least one Activity
-            Streams 2.0 activity type.
+            <code>type</code> &mdash; REQUIRED. An array of strings containing at least one
+            Activity Streams 2.0 activity type.
           </li>
           <li>
             <code>object</code> &mdash; REQUIRED. A JSON object identifying the resource
-            that the notification is about. The object MUST include an <code>id</code>
-            property with the resource URI and a <code>type</code> property.
+            that the notification is about. The <code>object</code> MUST include the
+            following properties:
+            <ul>
+              <li>
+                <code>id</code> &mdash; REQUIRED. The URI of the resource.
+              </li>
+              <li>
+                <code>type</code> &mdash; REQUIRED. An array of strings containing at least
+                one resource type. Values defined by [[!LWS-PROTOCOL]] include
+                <code>Container</code> and <code>DataResource</code>. Additional type values
+                MAY be included.
+              </li>
+            </ul>
           </li>
           <li>
-            <code>published</code> &mdash; REQUIRED. A datetime value indicating when the
-            activity occurred.
+            <code>published</code> &mdash; REQUIRED. A datetime value conforming to
+            [[!RFC3339]] indicating when the activity occurred.
           </li>
         </ul>
 
@@ -268,7 +293,7 @@
 
         <ul>
           <li>
-            <code>actor</code> &mdash; the agent that performed the action.
+            <code>actor</code> &mdash; a URI identifying the agent that performed the action.
           </li>
           <li>
             <code>target</code> &mdash; a URI identifying the container into which the
@@ -324,7 +349,7 @@
     "https://www.w3.org/ns/activitystreams"
   ],
   "type": "Notification",
-  "phase": "post-commit",
+  "phase": "PostCommit",
   "storage": "https://storage.example/",
   "activity": [
     {
@@ -332,7 +357,7 @@
       "type": ["Create"],
       "object": {
         "id": "https://storage.example/alice/notes/meeting.txt",
-        "type": "DataResource"
+        "type": ["DataResource"]
       },
       "target": "https://storage.example/alice/notes/",
       "published": "2026-03-26T10:30:00Z"
@@ -342,7 +367,7 @@
       "type": ["Update"],
       "object": {
         "id": "https://storage.example/alice/profile",
-        "type": "DataResource"
+        "type": ["DataResource"]
       },
       "published": "2026-03-26T10:30:01Z"
     }
@@ -356,8 +381,8 @@
       <h2>Subscriptions</h2>
 
       <p>
-        To receive notifications, a client creates a <a>subscription</a> by sending an
-        authenticated <code>POST</code> request to the <code>serviceEndpoint</code> of the
+        To receive notifications, a <a>subscriber</a> creates a <a>subscription</a> by sending
+        an authenticated <code>POST</code> request to the <code>serviceEndpoint</code> of the
         <code>NotificationService</code>. The request body MUST conform to the
         <code>application/lws+json</code> media type.
       </p>
@@ -376,14 +401,20 @@
             array of the <code>NotificationService</code>.
           </li>
           <li>
-            <code>phase</code> &mdash; REQUIRED. A string indicating the lifecycle phase for
-            which notifications are requested. The value MUST be <code>post-commit</code>.
-            Other values MAY be defined by future specifications.
-          </li>
-          <li>
             <code>topic</code> &mdash; REQUIRED. An array of URIs identifying the resources
-            included in the subscription. A subscription to a container includes notifications
-            for all resources contained in that container.
+            included in the subscription.
+          </li>
+        </ul>
+
+        <p>
+          A subscription request MAY contain the following fields:
+        </p>
+
+        <ul>
+          <li>
+            <code>phase</code> &mdash; OPTIONAL. A string indicating the lifecycle phase for
+            which notifications are requested. This specification defines the value
+            <code>PostCommit</code>.
           </li>
         </ul>
 
@@ -401,18 +432,57 @@ Content-Type: application/lws+json
 {
   "@context": ["https://www.w3.org/ns/lws/v1"],
   "type": "EventSourceSubscription",
-  "phase": "post-commit",
+  "phase": "PostCommit",
   "topic": [
     "https://storage.example/alice/notes/",
     "https://storage.example/alice/profile"
   ]
 }
         </pre>
+      </section>
+
+      <section id="subscription-scope">
+        <h3>Subscription Scope</h3>
 
         <p>
-          A server MUST enforce resource authorization. If an agent does not have the
-          equivalent of read access to all listed resources, a server MUST reject the
-          subscription request.
+          A <a>subscription</a> to a container is recursive: the <a>subscriber</a> receives
+          notifications for the container itself and for all resources transitively contained
+          in that container. A <a>subscription</a> to a data resource applies only to that
+          individual resource.
+        </p>
+      </section>
+
+      <section id="subscription-authorization">
+        <h3>Subscription Authorization</h3>
+
+        <p>
+          A server MUST enforce resource authorization when creating a <a>subscription</a>.
+          If a <a>subscriber</a> does not have the equivalent of read access to all resources
+          listed in the <code>topic</code> array, the server MUST reject the subscription
+          request.
+        </p>
+
+        <p>
+          Authorization MUST also be enforced at notification delivery time. A server MUST
+          NOT deliver a <a>notification</a> about a resource that the <a>subscriber</a> is
+          not authorized to read at the time the event occurs. This applies to all resources
+          within the scope of a <a>subscription</a>, including resources in subcontainers.
+        </p>
+
+        <p>
+          If the <a>subscriber</a>'s access to a resource or container within the scope of a
+          <a>subscription</a> is revoked after the <a>subscription</a> is created, the server
+          MUST stop delivering notifications for the affected resources. The server SHOULD
+          NOT terminate the entire <a>subscription</a> unless the <a>subscriber</a> has lost
+          access to all resources in the <code>topic</code> array.
+        </p>
+
+        <p class="note">
+          Subscription-time authorization verifies that a <a>subscriber</a> has a legitimate
+          basis for receiving notifications. Delivery-time authorization ensures that
+          notifications remain consistent with the <a>subscriber</a>'s current permissions,
+          accounting for authorization changes that may occur after the <a>subscription</a>
+          was created.
         </p>
       </section>
 
@@ -440,8 +510,8 @@ Content-Type: application/lws+json
       <h2>WebSocket Notifications</h2>
 
       <p>
-        The WebSocket notification channel allows a client to receive notifications over a
-        persistent WebSocket connection.
+        The WebSocket notification channel allows a <a>subscriber</a> to receive notifications
+        over a persistent WebSocket connection.
       </p>
 
       <section id="websocket-subscription">
@@ -480,9 +550,9 @@ Content-Type: application/lws+json
         <h3>Establishing a WebSocket Connection</h3>
 
         <p>
-          After obtaining a <a>capability URL</a>, the client opens a WebSocket connection to
-          that URL. The server sends notification envelopes as WebSocket text messages, serialized
-          as JSON.
+          After obtaining a <a>capability URL</a>, the <a>subscriber</a> opens a WebSocket
+          connection to that URL. The server sends notification envelopes as WebSocket text
+          messages, serialized as JSON.
         </p>
 
         <pre class="example" title="WebSocket client">
@@ -504,7 +574,7 @@ ws.onmessage = (event) => {
       <h2>Server-Sent Event Notifications</h2>
 
       <p>
-        The Server-Sent Event (SSE) notification channel allows a client to receive
+        The Server-Sent Event (SSE) notification channel allows a <a>subscriber</a> to receive
         notifications over a persistent HTTP connection using the EventSource API.
       </p>
 
@@ -544,8 +614,8 @@ ws.onmessage = (event) => {
         <h3>Establishing an EventSource Connection</h3>
 
         <p>
-          After obtaining a <a>capability URL</a>, the client establishes a persistent SSE
-          connection to that URL. The server responds with <code>Content-Type:
+          After obtaining a <a>capability URL</a>, the <a>subscriber</a> establishes a
+          persistent SSE connection to that URL. The server responds with <code>Content-Type:
           text/event-stream</code> and pushes notification envelopes as events. Each event
           MUST include an <code>id</code> field to support reconnection via the
           <code>Last-Event-ID</code> header.
@@ -572,7 +642,7 @@ source.onmessage = (event) => {
       <p>
         Webhooks enable server-to-server notification delivery. After a webhook subscription is
         created, the LWS storage server delivers notifications to the registered
-        <a>webhook endpoint</a> when relevant changes occur.
+        <a>webhook endpoint</a> of the <a>subscriber</a> when relevant changes occur.
       </p>
 
       <section id="webhook-subscription">
@@ -604,7 +674,7 @@ Content-Type: application/lws+json
 {
   "@context": ["https://www.w3.org/ns/lws/v1"],
   "type": "WebhookSubscription",
-  "phase": "post-commit",
+  "phase": "PostCommit",
   "topic": [
     "https://storage.example/alice/notes/",
     "https://storage.example/alice/profile"
@@ -651,24 +721,26 @@ Location: https://notification.example/subscriptions/9e8d7c6b5a4f
         <h3>Webhook Authentication</h3>
 
         <p>
-          When a server delivers a notification to a <a>webhook endpoint</a>, the receiving
-          party needs to verify that the request is authentic.
+          When a server delivers a notification to a <a>webhook endpoint</a>, the
+          <a>subscriber</a> needs to verify that the request is authentic.
         </p>
 
         <p>
           A server SHOULD sign each outbound request using HTTP Message Signatures
-          [[!RFC9421]]. When a <a>webhook endpoint</a> receives a signed message, it MUST verify
-          the signature using the notification server's public key, discoverable via the storage
-          description resource.
+          [[!RFC9421]]. When a <a>webhook endpoint</a> receives a signed message, it MUST
+          verify the signature using the notification server's public key, discoverable via
+          the storage description resource.
         </p>
 
         <p>
-          A server that supports HTTP Message Signatures MUST include the public portion of
-          its signing key in the storage description resource using a
-          <code>verificationMethod</code> property.
+          A server that supports HTTP Message Signatures MUST include the signing key in the
+          storage description resource. The key MUST be expressed as a verification method
+          in a <code>verificationMethod</code> array, and MUST be referenced from an
+          <code>authentication</code> verification relationship, following the Controlled
+          Identifiers 1.0 [[!CID-1.0]] data model.
         </p>
 
-        <pre class="example" title="Storage description with verification method">
+        <pre class="example" title="Storage description with verification method and authentication relationship">
 {
   "@context": ["https://www.w3.org/ns/lws/v1"],
   "id": "https://storage.example/",
@@ -686,6 +758,7 @@ Location: https://notification.example/subscriptions/9e8d7c6b5a4f
       "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"
     }
   }],
+  "authentication": ["https://storage.example/#key-20260320"],
   "service": [{
     "type": "NotificationService",
     "serviceEndpoint": "https://notification.example/subscriptions",
@@ -768,8 +841,8 @@ Location: https://notification.example/subscriptions/9e8d7c6b5a4f
         <p>
           The value of the <code>serviceEndpoint</code> property for a
           <code>NotificationService</code> that supports <code>WebhookSubscription</code>
-          MUST be a URL that supports <code>GET</code> operations to list an agent's active
-          webhook subscriptions. The resulting serialization MUST conform to the requirements
+          MUST be a URL that supports <code>GET</code> operations to list a <a>subscriber</a>'s
+          active webhook subscriptions. The resulting serialization MUST conform to the requirements
           for LWS Containers [[!LWS-PROTOCOL]]. The response SHOULD support LWS Paging.
         </p>
 
@@ -815,7 +888,7 @@ Location: https://notification.example/subscriptions/9e8d7c6b5a4f
         </li>
         <li>
           <strong>Webhook Verification</strong>: Without proper authentication on webhook
-          deliveries, an attacker could spoof notifications. Webhook receivers are strongly
+          deliveries, an attacker could spoof notifications. <a>Subscribers</a> are strongly
           encouraged to validate HTTP Message Signatures on all incoming notification requests
           using the public key published in the associated storage description resource.
         </li>
@@ -825,21 +898,15 @@ Location: https://notification.example/subscriptions/9e8d7c6b5a4f
         </li>
         <li>
           <strong>Signature Replay</strong>: A signed webhook request could be captured and
-          replayed by an attacker. Webhook receivers are encouraged to check the
+          replayed by an attacker. <a>Subscribers</a> are encouraged to check the
           <code>created</code> parameter in the <code>Signature-Input</code> field and reject
           signatures whose timestamp falls outside a reasonable clock-skew window.
         </li>
         <li>
           <strong>Information Disclosure</strong>: Notifications may reveal the existence or
-          modification patterns of resources. It is strongly recommended that access control on
-          subscriptions be consistent with access control on the underlying resources.
-        </li>
-        <li>
-          <strong>Phase Security</strong>: The <code>phase</code> property is defined with only
-          the <code>post-commit</code> value in this specification. Future specifications
-          defining additional lifecycle phases (such as pre-commit interception) MUST define
-          their own security requirements, particularly for synchronous request-response
-          patterns where a subscriber can influence resource persistence.
+          modification patterns of resources. Access control on subscriptions and on individual
+          notification delivery MUST be consistent with access control on the underlying
+          resources.
         </li>
       </ul>
     </section>
@@ -850,7 +917,7 @@ Location: https://notification.example/subscriptions/9e8d7c6b5a4f
       <ul>
         <li>
           <strong>Activity Tracking</strong>: Notifications inherently reveal when resources
-          change. Subscribers SHOULD only receive notifications for resources they are
+          change. <a>Subscribers</a> SHOULD only receive notifications for resources they are
           authorized to access.
         </li>
         <li>
@@ -909,6 +976,11 @@ Location: https://notification.example/subscriptions/9e8d7c6b5a4f
             <td>Webhook subscription type</td>
           </tr>
           <tr>
+            <td><code>PostCommit</code></td>
+            <td><code>lws:PostCommit</code></td>
+            <td>Notification phase indicating an event occurred after resource persistence</td>
+          </tr>
+          <tr>
             <td><code>subscriptionType</code></td>
             <td><code>lws:subscriptionType</code></td>
             <td>Supported subscription types on a notification service</td>
@@ -943,7 +1015,9 @@ Location: https://notification.example/subscriptions/9e8d7c6b5a4f
 
       <p>
         This document uses the following terms from external vocabularies, which should be
-        added to the LWS JSON-LD context:
+        added to the LWS JSON-LD context. The Activity Streams 2.0 terms are included in
+        the LWS context with their source IRIs from the
+        <code>https://www.w3.org/ns/activitystreams#</code> namespace.
       </p>
 
       <table class="simple">
@@ -956,19 +1030,64 @@ Location: https://notification.example/subscriptions/9e8d7c6b5a4f
         </thead>
         <tbody>
           <tr>
+            <td><code>Create</code></td>
+            <td><code>https://www.w3.org/ns/activitystreams#Create</code></td>
+            <td>Activity Streams 2.0</td>
+          </tr>
+          <tr>
+            <td><code>Update</code></td>
+            <td><code>https://www.w3.org/ns/activitystreams#Update</code></td>
+            <td>Activity Streams 2.0</td>
+          </tr>
+          <tr>
+            <td><code>Delete</code></td>
+            <td><code>https://www.w3.org/ns/activitystreams#Delete</code></td>
+            <td>Activity Streams 2.0</td>
+          </tr>
+          <tr>
+            <td><code>object</code></td>
+            <td><code>https://www.w3.org/ns/activitystreams#object</code></td>
+            <td>Activity Streams 2.0</td>
+          </tr>
+          <tr>
+            <td><code>actor</code></td>
+            <td><code>https://www.w3.org/ns/activitystreams#actor</code></td>
+            <td>Activity Streams 2.0</td>
+          </tr>
+          <tr>
+            <td><code>target</code></td>
+            <td><code>https://www.w3.org/ns/activitystreams#target</code></td>
+            <td>Activity Streams 2.0</td>
+          </tr>
+          <tr>
+            <td><code>origin</code></td>
+            <td><code>https://www.w3.org/ns/activitystreams#origin</code></td>
+            <td>Activity Streams 2.0</td>
+          </tr>
+          <tr>
+            <td><code>published</code></td>
+            <td><code>https://www.w3.org/ns/activitystreams#published</code></td>
+            <td>Activity Streams 2.0</td>
+          </tr>
+          <tr>
             <td><code>verificationMethod</code></td>
             <td><code>https://w3id.org/security#verificationMethod</code></td>
-            <td>Security Vocabulary</td>
+            <td>Controlled Identifiers 1.0</td>
+          </tr>
+          <tr>
+            <td><code>authentication</code></td>
+            <td><code>https://w3id.org/security#authenticationMethod</code></td>
+            <td>Controlled Identifiers 1.0</td>
           </tr>
           <tr>
             <td><code>controller</code></td>
             <td><code>https://w3id.org/security#controller</code></td>
-            <td>Security Vocabulary</td>
+            <td>Controlled Identifiers 1.0</td>
           </tr>
           <tr>
             <td><code>publicKeyJwk</code></td>
             <td><code>https://w3id.org/security#publicKeyJwk</code></td>
-            <td>Security Vocabulary</td>
+            <td>Controlled Identifiers 1.0</td>
           </tr>
           <tr>
             <td><code>inbox</code></td>

--- a/lws10-notifications/index.html
+++ b/lws10-notifications/index.html
@@ -202,13 +202,6 @@
         <h3>Envelope Properties</h3>
 
         <p>
-          The notification envelope carries metadata about the delivery context alongside
-          the activity payload. This includes the originating storage, the subscription
-          type, and an optional phase indicating at which point in the resource lifecycle
-          the notification was emitted.
-        </p>
-
-        <p>
           A notification envelope has the following properties:
         </p>
 

--- a/lws10-notifications/index.html
+++ b/lws10-notifications/index.html
@@ -143,12 +143,14 @@
           receives the resulting notifications.
         </li>
         <li>
-          <dfn>Capability URL</dfn> &mdash; a URL that encodes a subscription scope and
-          serves as the credential for establishing a notification connection.
+          <dfn>Inbox</dfn> &mdash; a URL controlled by a <a>subscriber</a> or other agent
+          to which a server delivers notifications via HTTP <code>POST</code>. An inbox is
+          used whenever the recipient of a notification is a server rather than a client
+          holding an open connection.
         </li>
         <li>
-          <dfn>Webhook Endpoint</dfn> &mdash; a URL controlled by a <a>subscriber</a> to
-          which the server delivers notifications via HTTP.
+          <dfn>Capability URL</dfn> &mdash; a URL that encodes a subscription scope and
+          serves as the credential for establishing a notification connection.
         </li>
       </ul>
     </section>
@@ -650,8 +652,8 @@ source.onmessage = (event) => {
 
       <p>
         Webhooks enable server-to-server notification delivery. After a webhook subscription is
-        created, the LWS storage server delivers notifications to the registered
-        <a>webhook endpoint</a> of the <a>subscriber</a> when relevant changes occur.
+        created, the LWS storage server delivers notifications to the <a>subscriber</a>'s
+        registered <a>inbox</a> when relevant changes occur.
       </p>
 
       <section id="webhook-subscription">
@@ -665,8 +667,8 @@ source.onmessage = (event) => {
 
         <ul>
           <li>
-            <code>inbox</code> &mdash; REQUIRED. The URI of the endpoint to which notification
-            messages are sent.
+            <code>inbox</code> &mdash; REQUIRED. The URI of the <a>inbox</a> to which
+            notification messages are delivered.
           </li>
           <li>
             <code>expires</code> &mdash; OPTIONAL. A datetime value indicating when the
@@ -730,13 +732,13 @@ Location: https://notification.example/subscriptions/9e8d7c6b5a4f
         <h3>Webhook Authentication</h3>
 
         <p>
-          When a server delivers a notification to a <a>webhook endpoint</a>, the
+          When a server delivers a notification to an <a>inbox</a>, the
           <a>subscriber</a> needs to verify that the request is authentic.
         </p>
 
         <p>
           A server SHOULD sign each outbound request using HTTP Message Signatures
-          [[!RFC9421]]. When a <a>webhook endpoint</a> receives a signed message, it MUST
+          [[!RFC9421]]. When an <a>inbox</a> receives a signed message, it MUST
           verify the signature using the notification server's public key, discoverable via
           the storage description resource.
         </p>
@@ -788,11 +790,11 @@ Location: https://notification.example/subscriptions/9e8d7c6b5a4f
             <li><code>@method</code> &mdash; the HTTP method of the request (always POST).</li>
             <li><code>@scheme</code> &mdash; prevents downgrade from https to http.</li>
             <li>
-              <code>@authority</code> &mdash; the host of the <a>webhook endpoint</a>,
+              <code>@authority</code> &mdash; the host of the <a>inbox</a>,
               preventing delivery to an unintended endpoint.
             </li>
             <li>
-              <code>@path</code> &mdash; the path component of the <a>webhook endpoint</a> URL.
+              <code>@path</code> &mdash; the path component of the <a>inbox</a> URL.
             </li>
             <li>
               <code>content-type</code> &mdash; the media type of the request body.
@@ -867,7 +869,7 @@ Location: https://notification.example/subscriptions/9e8d7c6b5a4f
 
         <p>
           The server sends an HTTP <code>POST</code> request to the registered
-          <a>webhook endpoint</a> with the notification envelope as the request body. The
+          <a>inbox</a> with the notification envelope as the request body. The
           request body MUST conform to the <code>application/lws+json</code> media type.
         </p>
 

--- a/lws10-notifications/index.html
+++ b/lws10-notifications/index.html
@@ -13,10 +13,18 @@
           name: "Jesse Wright",
           w3cid: "132252",
           company: "University of Oxford",
-          companyURL: "https://www.ox.ac.uk/"
+          companyURL: "https://www.ox.ac.uk/",
+        }, {
+          name: "Erich Bremer",
+          w3cid: "45759",
+          company: "Stony Brook University",
+          companyURL: "https://www.stonybrook.edu/",
         }],
         authors: [{
           name: "Laurens Debackere"
+        },
+        { 
+          name: "Aaron Coburn"
         }],
         github: "w3c/lws-protocol",
         xref: ["web-platform"],

--- a/lws10-vocab/vocabulary.yml
+++ b/lws10-vocab/vocabulary.yml
@@ -8,6 +8,10 @@ prefix:
     value: https://www.w3.org/ns/activitystreams#
   - id: schema
     value: https://schema.org/
+  - id: sec
+    value: https://w3id.org/security#
+  - id: ldp
+    value: http://www.w3.org/ns/ldp#
 
 ontology:
   - property: dc:title
@@ -40,6 +44,36 @@ class:
     label: OpenID Provider
     comment: An OpenID Connect identity provider service.
     defined_by: https://www.w3.org/TR/lws-authn-openid/
+
+  - id: Notification
+    label: Notification
+    comment: A notification envelope describing an event that occurred on a resource.
+    defined_by: https://www.w3.org/TR/lws-notifications/
+
+  - id: NotificationService
+    label: Notification Service
+    comment: A service through which clients subscribe to resource change notifications.
+    defined_by: https://www.w3.org/TR/lws-notifications/
+
+  - id: WebSocketSubscription
+    label: WebSocket Subscription
+    comment: A subscription type that delivers notifications over a WebSocket connection.
+    defined_by: https://www.w3.org/TR/lws-notifications/
+
+  - id: EventSourceSubscription
+    label: EventSource Subscription
+    comment: A subscription type that delivers notifications over a Server-Sent Events connection.
+    defined_by: https://www.w3.org/TR/lws-notifications/
+
+  - id: WebhookSubscription
+    label: Webhook Subscription
+    comment: A subscription type that delivers notifications via HTTP POST to a subscriber-provided inbox URL.
+    defined_by: https://www.w3.org/TR/lws-notifications/
+
+  - id: PostCommit
+    label: Post Commit
+    comment: A notification phase indicating the event occurred after the resource change was persisted.
+    defined_by: https://www.w3.org/TR/lws-notifications/
 
 property:
   - id: items
@@ -92,6 +126,101 @@ property:
   - id: PreferLinkRelations
     label: Prefer Link Relations
     comment: A preference URI for including or omitting specific link relations in responses.
+
+  - id: subscriptionType
+    label: subscription type
+    domain: lws:NotificationService
+    comment: The subscription types supported by a notification service.
+    defined_by: https://www.w3.org/TR/lws-notifications/
+
+  - id: subscription
+    label: subscription
+    range: xsd:anyURI
+    comment: The URL of the subscription resource or connection endpoint.
+    defined_by: https://www.w3.org/TR/lws-notifications/
+
+  - id: phase
+    label: phase
+    domain: lws:Notification
+    comment: The lifecycle phase at which the notification was emitted.
+    defined_by: https://www.w3.org/TR/lws-notifications/
+
+  - id: activity
+    label: activity
+    domain: lws:Notification
+    comment: The Activity Streams 2.0 activity payload within a notification.
+    defined_by: https://www.w3.org/TR/lws-notifications/
+
+  - id: topic
+    label: topic
+    range: xsd:anyURI
+    comment: An array of resource URIs covered by a subscription.
+    defined_by: https://www.w3.org/TR/lws-notifications/
+
+  - id: storage
+    label: storage
+    range: xsd:anyURI
+    comment: The URI identifying the LWS storage that emitted the notification.
+    defined_by: https://www.w3.org/TR/lws-notifications/
+
+  - id: as:Create
+    label: Create
+    comment: An activity representing the creation of a resource.
+
+  - id: as:Update
+    label: Update
+    comment: An activity representing the update of a resource.
+
+  - id: as:Delete
+    label: Delete
+    comment: An activity representing the deletion of a resource.
+
+  - id: as:object
+    label: object
+    comment: The primary object of an activity.
+
+  - id: as:actor
+    label: actor
+    comment: The agent that performed the activity.
+
+  - id: as:target
+    label: target
+    comment: The target of the activity.
+
+  - id: as:origin
+    label: origin
+    comment: The origin of a Move activity.
+
+  - id: as:published
+    label: published
+    range: xsd:dateTime
+    comment: The date and time the activity was published.
+
+  - id: sec:verificationMethod
+    label: verification method
+    comment: A verification method associated with a key or identity.
+
+  - id: sec:authentication
+    label: authentication
+    comment: An authentication method associated with an identity.
+
+  - id: sec:controller
+    label: controller
+    comment: The entity that controls a verification method.
+
+  - id: sec:publicKeyJwk
+    label: public key JWK
+    comment: A public key expressed as a JSON Web Key.
+
+  - id: ldp:inbox
+    label: inbox
+    range: xsd:anyURI
+    comment: A URL to which notifications are delivered via HTTP POST.
+
+  - id: schema:expires
+    label: expires
+    range: xsd:dateTime
+    comment: The date and time at which a subscription expires.
 
 json_ld:
   alias:


### PR DESCRIPTION
Resolves #103 

**This is a class 4 change to the protocol. It will need discussion and a WG vote before merging.**

This pull request introduces support for notifications in the project, including documentation and specification updates. The most important changes are grouped below:

**Documentation and Specification Updates:**

* Added a reference to the new `notifications` suite in the main `README.md` file to document its availability.
* Updated the `Discovery.html` example to enhance the `NotificationService` by specifying supported `subscriptionType` values, clarifying available notification mechanisms.
* Introducing an optional Notifications specification defining the mechanics of three distinct subscription types, i.e. Webhooks, SSE, and Websockets.

**Note: This is a draft PR, any feedback is welcome however.**


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/pull/129.html" title="Last updated on Apr 13, 2026, 2:48 PM UTC (29fa8fa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/129/d02eb9d...29fa8fa.html" title="Last updated on Apr 13, 2026, 2:48 PM UTC (29fa8fa)">Diff</a>