### PR TITLE
fix: generate html for readme file in repo root

### DIFF
--- a/.github/pandoc/template.html
+++ b/.github/pandoc/template.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>$title$</title>
+  $for(css)$<link rel="stylesheet" href="$css$"/>$endfor$
+</head>
+<body>
+  <main class="container">
+    $body$
+  </main>
+</body>
+</html>

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -31,6 +31,14 @@ jobs:
           npm ci
           npm run build
 
+      - name: Convert README to HTML
+        run: >
+          pandoc README.md -s
+          --metadata title="LWS Protocol"
+          --css https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css
+          --template .github/pandoc/template.html
+          -o index.html
+
       - uses: actions/upload-pages-artifact@v3
         with:
           path: .


### PR DESCRIPTION
In #112 a switch was made to Github Actions for the publication of our draft specifications via Github Pages. This however did break our "homepage" at http://w3c.github.io/lws-protocol/. 

This PR uses Pandoc to bring back this index page.