### PR TITLE
remove confusing analogy

### DIFF
--- a/lws10-core/Operations/create-resource.md
+++ b/lws10-core/Operations/create-resource.md
@@ -1,4 +1,4 @@
-The **create resource** operation adds a new [served resource](#dfn-served-resource) to an existing [container](#dfn-container). This operation handles both the creation of data resources (files) and sub-containers.
+The **create resource** operation adds a new [served resource](#dfn-served-resource) to an existing [container](#dfn-container). This operation handles both the creation of data resources and sub-containers.
 
 **Inputs:**
 


### PR DESCRIPTION
I assume that the idea was to help the reader with an analogy between the "data resource / container" dichotomy, and the familiar "file / folder" dichotomy.

But this can also be confusing or counter-productive, as "file" brings undesirable connotations - plus, this analogy is not further developed or explained.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/pull/136.html" title="Last updated on Apr 20, 2026, 1:09 PM UTC (f9ce8fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/136/2e976ee...f9ce8fb.html" title="Last updated on Apr 20, 2026, 1:09 PM UTC (f9ce8fb)">Diff</a>