### PR TITLE
Rename container section to 'Containers'

### DIFF
--- a/lws10-core/index.html
+++ b/lws10-core/index.html
@@ -242,8 +242,8 @@
 	  <div data-include="logicalresourceorganization.md" data-include-format="markdown" data-include-replace="true"></div>
     </section>
 
-    <section id="container-representation">
-      <h2>Container Representation</h2>
+    <section id="containers">
+      <h2>Containers</h2>
 	  <div data-include="container-representation.md" data-include-format="markdown" data-include-replace="true"></div>
     </section>
 


### PR DESCRIPTION
At present, both section 8 and section 8.1 have the title "Container Representation", which is potentially misleading. This changes the section 8 title to "Containers"


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/pull/154.html" title="Last updated on May 18, 2026, 2:36 PM UTC (1a1217d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/154/0147630...1a1217d.html" title="Last updated on May 18, 2026, 2:36 PM UTC (1a1217d)">Diff</a>