### PR TITLE
move former editors to Acknowledgement section

### DIFF
--- a/lws10-core/index.html
+++ b/lws10-core/index.html
@@ -362,7 +362,7 @@
     <section id="acknowledgements" class="appendix informative">
       <h2>Acknowledgements</h2>
       <p>This specification draws heavily from the Solid Protocol [[Solid-Protocol]], which was edited, over time, by
-         Sarven Capadisli, Tim Berners-Lee, Kjetil Kjernsmo, Ruben Verborgh, Justin-Bingham, Dmitri-Zagidulin.
+         Sarven Capadisli, Tim Berners-Lee, Kjetil Kjernsmo, Ruben Verborgh, Justin Bingham, Dmitri Zagidulin.
       </p>
     </section>
   </body>

--- a/lws10-core/index.html
+++ b/lws10-core/index.html
@@ -22,19 +22,6 @@
           company: "Stony Brook University",
           companyURL: "https://www.stonybrook.edu/",
         }],
-        formerEditors: [{
-          name: "Sarven Capadisli",
-        }, {
-          name: "Justin Bingham",
-        }, {
-          name: "Dmitri Zagidulin",
-        }, {
-          name: "Ruben Verborgh",
-        }, {
-          name: "Tim Berners-Lee",
-        }, {
-          name: "Kjetil Kjernsmo",
-        }],
         github: "w3c/lws-protocol",
         xref: ["web-platform"],
         group: "lws",
@@ -121,7 +108,7 @@
     <section id="conventions" class="informative">
       <h2>Document Conventions</h2>
       <dl>
-        <dt></dt><dd><dd/>
+        <dt></dt><dd></dd>
       </dl>
     </section>
 
@@ -370,6 +357,13 @@
     <section id="iana-considerations" class="informative">
       <h2>IANA Considerations</h2>
       <div data-include="IANA-Considerations.html" data-include-replace="true"></div>
+    </section>
+
+    <section id="acknowledgements" class="appendix informative">
+      <h2>Acknowledgements</h2>
+      <p>This specification draws heavily from the Solid Protocol [[Solid-Protocol]], which was edited, over time, by
+         Sarven Capadisli, Tim Berners-Lee, Kjetil Kjernsmo, Ruben Verborgh, Justin-Bingham, Dmitri-Zagidulin.
+      </p>
     </section>
   </body>
 </html>


### PR DESCRIPTION
per the WG discussion at https://www.w3.org/2026/03/16-lws-minutes.html#74e1

this PR focuses on the people who appeared as 'former editors', it does not preclude adding more people to the Acknowledgement section.

also, this PR fixes an HTML bug line 111


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/pull/160.html" title="Last updated on May 27, 2026, 11:12 AM UTC (5e0e0d8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/160/dd52c75...5e0e0d8.html" title="Last updated on May 27, 2026, 11:12 AM UTC (5e0e0d8)">Diff</a>