### PR TITLE
Define aux & meta in terms of representations

### DIFF
--- a/lws10-core/index.html
+++ b/lws10-core/index.html
@@ -129,7 +129,7 @@
       <h2>Introduction</h2>
       <p>
       </p>
-      
+
       <section id="resource-access">
         <h2>Resource Access</h2>
         <p>
@@ -144,7 +144,7 @@
         <p>
         </p>
       </section>
-      
+
       <section id="security-privacy">
         <h2>Security and Privacy</h2>
         <p>
@@ -192,15 +192,16 @@
           capability such as ZCAPs.
         </li>
         <li><dfn>authentication suite</dfn> &mdash; a defined validation mechanism for a concrete serialization of an <a>authentication credential</a>.</li>
-        <li><dfn>auxiliary resource</dfn> &mdash; an <a>LWS resource</a> whose lifecycle is bound to another <a>LWS resource</a>, called its <dfn>principal resource</dfn>.</li>
+        <li><dfn>auxiliary resource</dfn> &mdash; an <a>LWS resource</a> whose lifecycle is bound to another -- non-auxiliary -- <a>LWS resource</a>, called its <dfn>primary resource</dfn>. One type of auxiliary resources are <a>metadata resources</a>, as defined in this specification, but <a>LWS Servers</a> are free to manage additional kinds of auxiliary resources (e.g., access control resources, notification inboxes).</li>
         <li><dfn data-lt="LWS resources">LWS resource</dfn> &mdash; an HTTP <a>resource</a> as defined in [[[RFC9110]]] which supports the read operations defined by the Linked Web Storage Protocol.
         Following [[[RFC9110]]], this specification "does not limit the nature of a [LWS] resource; it merely defines an interface that might be used to interact with [LWS] resources." [[RFC9110]]
         </li>
         <li><dfn>container</dfn> &mdash; an <a>LWS resource</a> that is able to enumerate a collection of <a>LWS resources</a>, conforming to the conventions described in <a href="#container-representation">Section 8. Containers</a>. The ability to create new resources in a container or to delete an existing container follows the requirements outlined in <a href="#operations">Section 9. Operations</a>.</li>
         <li><dfn>data resource</dfn> &mdash; a data-bearing <a>LWS resource</a> such as a document, image, or structured information whose support for update and delete operations follows the requirements outlined in <a href="#operations">Section 9. Operations</a>.</li>
         <li><dfn>containment</dfn> &mdash; the relationship between a <a>container</a> and the <a>LWS resources</a> whose lifecycle the <a>container</a> manages.</li>
-        <li><dfn>linkset resource</dfn> &mdash; a type of <a>auxiliary resource</a> whose representation conforms to [[[RFC9264]]]. Update operations for linkset resources follow the requirements outlined in <a href="#operations">Section 9. Operations</a>.</li>
-        <li><dfn>metadata resource</dfn> &mdash; an <a>auxiliary resource</a>, managed by a <a>storage</a>, that describes an <a>LWS resource</a> and conforms to the conventions described in <a href="todo-metadata-resource">TBD</a>. The lifecycle of a metadata resource is bound to the <a>LWS resource</a> it describes.</li>
+        <li><dfn>linkset representation</dfn> &mdash; a <a>metadata representation</a> containing the linkset of an <a>LWS resource</a>, conforming to [[[RFC9264]]]. The <a>metadata resource</a> exposing this representation is called the <dfn>linkset document</dfn> of the <a>primary resource</a>. Updates of linkset representations follow the requirements outlined in <a href="#operations">Section 9. Operations</a>.</li>
+        <li><dfn>metadata representation</dfn> &mdash; a representation of an <a>LWS resource</a>, that provides additional information describing the resource.</li>
+        <li><dfn>metadata resource</dfn> &mdash; an <a>auxiliary resource</a> that exposes a specific <a>metadata representation</a> of its <a>primary resource</a>, and conforms to the conventions described in <a href="todo-metadata-resource">TBD</a>.</li>
         <li><dfn data-cite="webarch#def-resource">resource</dfn> &mdash; a resource is, as described by [[WebArch]] and [[RFC3986]], “whatever might be identified by a URI”. Resources whose essential characteristics can be conveyed in a message (such as web pages, images, structured data objects...) are called <dfn data-cite="webarch#def-information-resource">information resources</dfn> [[WebArch]].
         <li><dfn>storage</dfn> &mdash; a set of hierarchically organized HTTP resources whose lifecycle is managed by the conventions described by the Linked Web Storage Protocol. A storage is described by a <a>storage description resource</a> which references a collection of services that provide affordances over those resources.</li>
         <li><dfn>storage controller</dfn> &mdash; an <a>agent</a> that controls all resources in a <a>storage</a>.</li>
@@ -260,13 +261,13 @@
     <section id="operations">
       <h2>Operations</h2>
 	  <div data-include="operations.md" data-include-format="markdown" data-include-replace="true"></div>
-	  
+
 	  <div data-include="Operations/restbinding.md" data-include-format="markdown" data-include-replace="true"></div>
 	  <div data-include="Operations/metadata.md" data-include-format="markdown" data-include-replace="true"></div>
 
       <section id="create-resource">
         <h2>Create resource</h2>
-		<div data-include="Operations/create-resource.md" data-include-format="markdown" data-include-replace="true"></div>		
+		<div data-include="Operations/create-resource.md" data-include-format="markdown" data-include-replace="true"></div>
       </section>
 
       <section id="read-resource">
@@ -315,7 +316,7 @@
           <li>Lack of implementation of those features</li>
         </ul>
       </div>
-	  
+
 	  <div data-include="Unstable-Features.md" data-include-format="markdown" data-include-replace="true"></div>
 
       <section id="profile-negotiation">


### PR DESCRIPTION
Resolves #67, #125, #127, #147
Supersedes #113

This PR updates #153 to address the tension around auxiliary/metadata resources. In short, it redefines the must-haves in terms of representations, on top of which the (optional) resource variant is then defined.

## Definitions

For clarity, here are the adapted definitions in a logical order.

- **metadata representation**: a representation of an *LWS resource*, that provides additional information describing the resource.

- **linkset representation**: a *metadata representation* containing the linkset of an *LWS resource*, conforming to RFC9264. The *metadata resource* exposing this representation is called the **linkset document** of the *primary resource*. Updates of linkset representations follow the requirements outlined in Section 9. Operations.

- **metadata resource**: an *auxiliary resource* that exposes a specific *metadata representation* of its *primary resource*, and conforms to the conventions described in ...

- **auxiliary resource**: an *LWS resource* whose lifecycle is bound to another -- non-auxiliary -- *LWS resource*, called its **primary resource**. One type of auxiliary resources are *metadata resources*, as defined in this specification, but *LWS Servers* are free to manage additional kinds of auxiliary resources (e.g., access control resources, notification inboxes).

## Conformance 

Since we agreed to keep the terminology high-level, I've left out a number of important details, which I summarize here to take up in one or more future PRs.

- Linksets are unique per primary resource.
- The linkset representation can be requested through content negotiation for `application/linkset+json`.
- Linksets can be modified by clients to manage their primary resource's relationships, except for certain protected link types specified by the server.
- Auxiliary resources (if any) are not contained in a container hierarchy.
    - However, LWS servers are free to list them as part of their primary resource's contained resource description.
- The URI of an auxiliary resource (if any) is discoverable from its primary resource via Link headers of the appropriate relation type.
- The URI of an metadata resource (if any) is declared in the Content-Location header field in response to content-negotiated requests for its corresponding metadata representation targeting its primary resource's URI

For anyone who is less familiar with that header, here's an excerpt from [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html) (HTTP Semantics):

> The "Content-Location" header field references a URI that can be used as an identifier for a specific resource corresponding to the representation in this message's content ... For a response to a GET or HEAD request, this is an indication that the target URI refers to a resource that is subject to content negotiation and the Content-Location field value is a more specific identifier for the selected representation.

## Additional suggestions

- Require the use of the **linkset type parameter**.
- Specify the **containment representation** of a container as a type of metadata representation.
- Treat the **conformance w.r.t. metadata** uniformly across LWS resource types (so also for non-RDF resources).
    - This separates server- vs. client-managed metadata more clearly.
    - It also diminishes the 'special role' of RDF; e.g., servers could provide non-RDF metadata representations for RDF resources).
- Define a specific metadata representation containing all server-managed metadata of a resource.
    - This representation can be read-only, so can be (profiled) JSON-LD, including not only the linkset as triples but also **literal metadata**.
- Specify a client-managed link relation type (e.g., `rel="describedby"`) that turns a resource into a metadata resource for another (primary) resource.
    - Their lifecycle is then managed by the server in accordance with its primary resource.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/termontwouter/lws-protocol/pull/163.html" title="Last updated on May 18, 2026, 1:53 PM UTC (6e2c659)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/163/fa2e4eb...termontwouter:6e2c659.html" title="Last updated on May 18, 2026, 1:53 PM UTC (6e2c659)">Diff</a>