### PR TITLE
auxiliary resource as a role

### DIFF
--- a/lws10-core/index.html
+++ b/lws10-core/index.html
@@ -198,7 +198,7 @@
         <li><dfn>storage</dfn> &mdash; a set of hierarchically organized HTTP resources whose lifecycle is managed by the conventions described by the Linked Web Storage Protocol. A storage is described by a <a>storage description resource</a> which references a collection of services that provide affordances over those resources.</li>
         <li><dfn>storage controller</dfn> &mdash; an <a>agent</a> that controls all resources in a <a>storage</a>.</li>
         <li><dfn data-lt="storage description resource">storage description</dfn> &mdash; an <a>LWS resource</a> that enumerates and describes the <a>storage root</a> along with services and capabilities of a <a>storage</a>. Its representation conforms to the storage description data model.</li>
-        <li><dfn>storage root</dfn> &mdash; a <a>container</a> at the root of a <a>containment</a> hierarchy of a <a>storage</a>. The storage root is the only <a>LWS resource</a> that does not have a parent in the LWS <a>containment</a> hierarchy nor a <a>principal resource</a>.</li>
+        <li><dfn>storage root</dfn> &mdash; a <a>container</a> at the root of a <a>containment</a> hierarchy of a <a>storage</a>. The storage root is the only <a>LWS resource</a> that does not have a parent in the LWS <a>containment</a> hierarchy nor a <a>primary resource</a>.</li>
       </ul>
 
       <div class="issue atrisk" title="Section may be removed">

--- a/lws10-core/index.html
+++ b/lws10-core/index.html
@@ -179,7 +179,13 @@
           capability such as ZCAPs.
         </li>
         <li><dfn data-lt="authentication suites">authentication suite</dfn> &mdash; a defined validation mechanism for a concrete serialization of an <a>authentication credential</a>.</li>
-        <li><dfn>auxiliary resource</dfn> &mdash; an <a>LWS resource</a> whose lifecycle is bound to an <a>LWS resource</a>, called its <dfn>principal resource</dfn>.</li>
+        <li><dfn>auxiliary resource</dfn> &mdash; an <a>LWS resource</a> that plays a particular role with respect to a <a>LWS resource</a>, called its <dfn>primary resource</dfn>,
+        and whose lifetime is bound to the primary resource.
+        This specification defines <a>linkset resource</a> and <a>metadata resource</a> as types of auxiliary resources,
+        but <a>LWS Servers</a> are free to manage additional kinds of auxiliary resources (e.g. access control resources, notification inboxes).
+        Auxiliary resources are discovered using links of a specific type (see Section <a href="#metadata"></a>).
+        Some auxiliary resources may, in some implementations, be identical to their primary resource.
+        </li>
         <li><dfn data-lt="LWS resources">LWS resource</dfn> &mdash; an HTTP <a>resource</a> as defined in [[[RFC9110]]] which supports the read operations defined by the Linked Web Storage Protocol.
         Following [[[RFC9110]]], this specification "does not limit the nature of a [LWS] resource; it merely defines an interface that might be used to interact with [LWS] resources." [[RFC9110]]
         </li>

--- a/lws10-core/index.html
+++ b/lws10-core/index.html
@@ -183,7 +183,7 @@
         and whose lifetime is bound to the primary resource.
         This specification defines <a>linkset resource</a> and <a>metadata resource</a> as types of auxiliary resources,
         but <a>LWS Servers</a> are free to manage additional kinds of auxiliary resources (e.g. access control resources, notification inboxes).
-        Auxiliary resources are discovered using links of a specific type (see Section <a href="#metadata"></a>).
+        Auxiliary resources are discovered using web links [[RFC8288]] of a specific type (see Section <a href="#metadata"></a>).
         Some auxiliary resources may, in some implementations, be identical to their primary resource.
         </li>
         <li><dfn data-lt="LWS resources">LWS resource</dfn> &mdash; an HTTP <a>resource</a> as defined in [[[RFC9110]]] which supports the read operations defined by the Linked Web Storage Protocol.


### PR DESCRIPTION
this is an alternative proposal to #165 

instead of splitting metadata and linkset in terms of representation / resource,
it clarifies that an *auxiliary resource* is not necessarily disjoint from its *primary resource*;
the terms do not denote special kinds of resources, but roles that resources play w.r.t. each other (and that, in some circumstances, a resource can play for itself).

What does not change:
* an auxiliary resource is still defined by its lifetime being bound to the primary resource (this is obviously the case if they are the same)

What changes:
* the new definition makes it more explicit that the auxiliary resource has a specific role w.r.t. the primary resource (e.g. its "linkset resource", its "ACL resource"...). I believe that was the intent of the previous definition, but now that is more clearly spelled out.
* the new definition makes it explicit that web links (as per [RFC8288](https://www.rfc-editor.org/rfc/rfc8288.html) are how auxiliary resources are discovered (but does not currently preclude how those links are conveyed: HTTP headers, in the linkset resources, other ways... possibly in the RDF representation of the resource itself...). I'm not sure this was entirely decided so far.
* the new definition makes it explicit that auxiliary resource and primary resource could be one and the same (with the link pointing to the same URI, as suggested by @acoburn during today's call)

Notes:
* the definition is currently a bit long; some parts of it could be moved in the text of the spec; my goal was to make it clear and easy to review what the proposed direction was.
* I stole some text from @termontwouter 's PR #165, describing examples of auxiliary resources; thanks to him :)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/pull/167.html" title="Last updated on Jun 22, 2026, 3:03 PM UTC (078b0cb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/167/91e6d6e...078b0cb.html" title="Last updated on Jun 22, 2026, 3:03 PM UTC (078b0cb)">Diff</a>