### PR TITLE
Remove 'Unstable Features' section

### DIFF
--- a/lws10-core/Unstable-Features.md
+++ b/lws10-core/Unstable-Features.md
@@ -1,4 +1,0 @@
-this left intentionally blank
-
-
-

--- a/lws10-core/Unstable-Features/Inbox.md
+++ b/lws10-core/Unstable-Features/Inbox.md
@@ -1,4 +1,0 @@
-this left intentionally blank
-
-
-

--- a/lws10-core/Unstable-Features/Notifications.md
+++ b/lws10-core/Unstable-Features/Notifications.md
@@ -1,5 +1,0 @@
-# Notifications
-
-The [LWS Notifications](../../lws10-notifications/index.html) specification extends the Linked Web Storage (LWS) protocol with a mechanism for clients to receive timely updates about changes to resources via Webhooks — server-to-server push notifications with HTTP Message Signatures.
-
-The notification data model is based on Activity Streams and is discoverable via the storage description resource.

--- a/lws10-core/Unstable-Features/Profile-Negotiation-on-Resources.md
+++ b/lws10-core/Unstable-Features/Profile-Negotiation-on-Resources.md
@@ -1,4 +1,0 @@
-this left intentionally blank
-
-
-

--- a/lws10-core/index.html
+++ b/lws10-core/index.html
@@ -296,45 +296,6 @@
 		<div data-include="Resource-Identification.md" data-include-format="markdown" data-include-replace="true"></div>
     </section>
 
-    <section id="unstable-features" data-feature-status="unstable">
-      <h2>Unstable Features</h2>
-      <div class="advisement">
-        <p>
-          The features described in this section are being drafted to ground discussions and may be removed if there is:
-        </p>
-        <ul>
-          <li>Lack of consensus to include them, or</li>
-          <li>Lack of implementation of those features</li>
-        </ul>
-      </div>
-	  
-	  <div data-include="Unstable-Features.md" data-include-format="markdown" data-include-replace="true"></div>
-
-      <section id="profile-negotiation">
-        <h3>Profile Negotiation on Resources</h3>
-        <p>
-          <span class="TODO">Define mechanisms for content negotiation based on profiles, allowing clients to request specific representations or views of resources (e.g., JSON-LD contexts, different RDF serializations, or application-specific profiles).</span>
-        </p>
-		<div data-include="Unstable-Features/Profile-Negotiation-on-Resources.md" data-include-format="markdown" data-include-replace="true"></div>
-      </section>
-
-      <section id="notifications">
-        <h3>Notifications</h3>
-        <p>
-          <span class="TODO">Define notification mechanisms that allow clients to be informed of changes to resources, including subscription models, event formats, and delivery mechanisms.</span>
-        </p>
-		<div data-include="Unstable-Features/Notifications.md" data-include-format="markdown" data-include-replace="true"></div>
-      </section>
-
-      <section id="inbox-semantics">
-        <h3>Inbox</h3>
-        <p>
-          <span class="TODO">Define inbox resources with specific semantics within LWS, including message posting, retrieval, and management capabilities for asynchronous communication patterns.</span>
-        </p>
-		<div data-include="Unstable-Features/Inbox.md" data-include-format="markdown" data-include-replace="true"></div>
-      </section>
-    </section>
-
     <section id="portability-considerations">
       <h2>Portability Considerations</h2>
       <p>


### PR DESCRIPTION
This removes the separate '[Unstable Features](https://www.w3.org/TR/lws10-core/#unstable-features)' section.

In general, any unstable feature should be marked as such in-line rather than as a separate section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/pull/168.html" title="Last updated on Jun 18, 2026, 3:17 PM UTC (1f0b86a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/168/e4c2c06...1f0b86a.html" title="Last updated on Jun 18, 2026, 3:17 PM UTC (1f0b86a)">Diff</a>