### PR TITLE
LWS Implementation tracking

### DIFF
--- a/Implementations.md
+++ b/Implementations.md
@@ -8,7 +8,7 @@
 
 | Name | Contact | License | Client | Server |
 |------|---------|---------|--------|--------|
-| [sai-js](https://sai.js.org) | [@elf-pavlik](https://github.com/elf-pavlik) | MIT | 🟢 | 🟡 |
+| [sai-js](https://sai.js.org) | [@elf-pavlik](https://github.com/elf-pavlik) | MIT | 🟢 | 🟡 [^1] |
 |      |         |         |        |        |
 
 ## Features
@@ -25,3 +25,8 @@
 | Name | Client | Server |
 |------|--------|--------|
 | sai-js | 💡| 💡|
+
+
+## Notes
+
+[^1]: sai-js server is implemented as custom components for [Community Solid Server](https://communitysolidserver.github.io/CommunitySolidServer/)

--- a/Implementations.md
+++ b/Implementations.md
@@ -2,13 +2,13 @@
 
 ## Software
 
-* 🟢 Applicable
-* 🟡 Partially Applicable
-* 🔴 Not Applicable
+* ● Applicable
+* ◐ Partially Applicable
+* ○ Not Applicable
 
 | Name | Contact | License | Client | Server |
 |------|---------|---------|--------|--------|
-| [sai-js](https://sai.js.org) | [@elf-pavlik](https://github.com/elf-pavlik) | MIT | 🟢 | 🟡 [^1] |
+| [sai-js](https://sai.js.org) | [@elf-pavlik](https://github.com/elf-pavlik) | MIT | ● | ◐ [^1] |
 |      |         |         |        |        |
 
 ## Features
@@ -22,10 +22,12 @@
 
 ## Type Index and Type Search
 
+https://w3c.github.io/lws-protocol/lws10-searchindex
+
 | Name | Client | Server |
 |------|--------|--------|
 | sai-js | 💡| 💡|
-
+|  |  |  |
 
 ## Notes
 

--- a/Implementations.md
+++ b/Implementations.md
@@ -1,0 +1,27 @@
+# LWS Implementations
+
+## Software
+
+* 🟢 Applicable
+* 🟡 Partially Applicable
+* 🔴 Not Applicable
+
+| Name | Contact | License | Client | Server |
+|------|---------|---------|--------|--------|
+| [sai-js](https://sai.js.org) | [@elf-pavlik](https://github.com/elf-pavlik) | MIT | 🟢 | 🟡 |
+|      |         |         |        |        |
+
+## Features
+
+*all 🔗 links are optional*
+
+* 💡 Interested
+* 🎯 Committed  (🔗 tracking issue)
+* 🚧 Implementing (🔗 code or feature branch)
+* ✅ Conforming (🔗 test results)
+
+## Type Index and Type Search
+
+| Name | Client | Server |
+|------|--------|--------|
+| sai-js | 💡| 💡|

--- a/Implementations.md
+++ b/Implementations.md
@@ -9,6 +9,7 @@
 | Name | Contact | License | Client | Server |
 |------|---------|---------|--------|--------|
 | [sai-js](https://sai.js.org) | [@elf-pavlik](https://github.com/elf-pavlik) | MIT | ● | ◐ [^1] |
+| [sparq](https://sparq.jeswr.org/) | [Jesse Wright](https://jeswr.org/#me) | MIT | ○ | ● |
 |      |         |         |        |        |
 
 ## Features

--- a/Implementations.md
+++ b/Implementations.md
@@ -10,6 +10,9 @@
 |------|---------|---------|--------|--------|
 | [sai-js](https://sai.js.org) | [@elf-pavlik](https://github.com/elf-pavlik) | MIT | ● | ◐ [^1] |
 | [sparq](https://sparq.jeswr.org/) | [Jesse Wright](https://jeswr.org/#me) | MIT | ○ | ● |
+| [lws-server](https://github.com/ebremer/lws-server) | [@ebremer](https://github.com/ebremer) | Apache License 2.0 |  ○  |  ●  |
+| [lws-authn](https://github.com/ebremer/lws-authn) | [@ebremer](https://github.com/ebremer) | Apache License 2.0 |  ○  |  ●  |
+|      |         |         |        |        |
 |      |         |         |        |        |
 
 ## Features
@@ -21,9 +24,107 @@
 * 🚧 Implementing (🔗 code or feature branch)
 * ✅ Conforming (🔗 test results)
 
-## Type Index and Type Search
 
-https://w3c.github.io/lws-protocol/lws10-searchindex
+### Authentication & Authorization
+
+* https://github.com/ebremer/lws-authn
+* https://www.w3.org/TR/lws10-core/#authorization
+* https://github.com/lws-contrib/lws-test-suite/tree/main/lws10/auth
+
+
+| Name | Client | Server |
+|------|--------|--------|
+| lws-authn  | | 🚧|
+|  |  |  |
+
+
+#### OpenID Connect
+
+* https://w3c.github.io/lws-protocol/lws10-authn-openid/
+
+| Name | Client | Server |
+|------|--------|--------|
+| lws-authn  | | 🚧|
+| sai-js | | 💡|
+|  |  |  |
+
+#### SAML 2.0
+
+* https://w3c.github.io/lws-protocol/lws10-authn-saml/
+
+| Name | Client | Server |
+|------|--------|--------|
+| lws-authn  | | 🚧|
+|  |  |  |
+
+#### Self-signed Controlled Identifier
+
+* https://w3c.github.io/lws-protocol/lws10-authn-ssi-cid/
+
+| Name | Client | Server | Notes |
+|------|--------|--------|-------|
+| lws-authn  | | 🚧| https, did:key |
+| sai-js | | 💡|
+|  |  |  |
+
+### Access Requests and Grants
+
+* https://w3c.github.io/lws-protocol/lws10-core/#access-requests-and-grants
+
+| Name | Client | Server |
+|------|--------|--------|
+| sai-js | | 🚧|
+|  |  |  |
+
+#### ODRL Access Profile
+
+* https://w3c.github.io/lws-protocol/lws10-core/#access-profile
+
+| Name | Client | Server |
+|------|--------|--------|
+| sai-js | | 💡|
+|  |  |  |
+
+### Notifications
+
+* https://w3c.github.io/lws-protocol/lws10-core/#notifications
+
+| Name | Client | Server |
+|------|--------|--------|
+| sai-js | | 🚧|
+|  |  |  |
+
+#### Webhook
+
+* https://w3c.github.io/lws-protocol/lws10-notifications-webhook/
+
+| Name | Client | Server | Notes |
+|------|--------|--------|-------|
+| sai-js | | 🚧|
+|  |  |  |
+|  |  |  |
+
+#### Streaming HTTP
+
+* https://github.com/w3c/lws-protocol/pull/162 
+
+| Name | Client | Server | Notes |
+|------|--------|--------|-------|
+| sai-js | | 🚧| NDJSON |
+|  |  |  |
+
+#### Webhook
+
+* https://w3c.github.io/lws-protocol/lws10-notifications-webhook/
+
+| Name | Client | Server | Notes |
+|------|--------|--------|-------|
+| sai-js | | 💡|
+|  |  |  |
+
+#### Type Index and Type Search
+
+* https://w3c.github.io/lws-protocol/lws10-searchindex
 
 | Name | Client | Server |
 |------|--------|--------|

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ To see the most recent HTML rendered version of the specification from this repo
 - [`authn-ssi-did-key`](lws10-authn-ssi-did-key): Self-signed `did:key` Authentication Suite
 - [`notifications`](lws10-notifications/): Notifications
 
+## (1.0) Implementations:
+
+[Implementations.md](Implementations.md) <- please signal interest and progress via PR
+
 
 ## Contribution Guidelines:
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ To see the most recent HTML rendered version of the specification from this repo
 - [`notifications-webhook`](lws10-notifications-webhook/): Notification Suite: Webhooks
 - [`searchindex`](lws10-searchindex/): Search and Type Index Services
 
+## (1.0) Implementations:
+
+[Implementations.md](Implementations.md) <- please signal interest and progress via PR
+
 
 ## Contribution Guidelines:
 


### PR DESCRIPTION
closes #170 

A lightweight way to track implementations per feature. Starting with
* #115 

LWS currently doesn't clearly distinguish different classes of products. This may be needed for the test suite / test manifests as `spec:requriementSubject`.

Eventually I would aim for something more detailed as this old experiment (conformance numbers are random)
https://elf-pavlik.github.io/solid-efforts/#/implementation?id=https://solidproject.solidcommunity.net/catalog/data%23CSS