### PR TITLE
Add missing local.css files to authentication suites

### DIFF
--- a/lws10-authn-openid/local.css
+++ b/lws10-authn-openid/local.css
@@ -1,0 +1,7 @@
+.TODO { background-color: #fcc }
+
+.informative { border-left: .3em solid #ccf; margin-left: -.3em; }
+
+.editors-notes {
+  background-color: lightYellow;
+}

--- a/lws10-authn-saml/local.css
+++ b/lws10-authn-saml/local.css
@@ -1,0 +1,7 @@
+.TODO { background-color: #fcc }
+
+.informative { border-left: .3em solid #ccf; margin-left: -.3em; }
+
+.editors-notes {
+  background-color: lightYellow;
+}

--- a/lws10-authn-ssi-cid/local.css
+++ b/lws10-authn-ssi-cid/local.css
@@ -1,0 +1,7 @@
+.TODO { background-color: #fcc }
+
+.informative { border-left: .3em solid #ccf; margin-left: -.3em; }
+
+.editors-notes {
+  background-color: lightYellow;
+}

--- a/lws10-authn-ssi-did-key/local.css
+++ b/lws10-authn-ssi-did-key/local.css
@@ -1,0 +1,7 @@
+.TODO { background-color: #fcc }
+
+.informative { border-left: .3em solid #ccf; margin-left: -.3em; }
+
+.editors-notes {
+  background-color: lightYellow;
+}


### PR DESCRIPTION
Echidna runs a check on all link references before publishing, and the authentication suites are each missing a `local.css` file that contains definitions for `.TODO`, `.editors-notes`, and `.informative`. This causes the echidna publication automation to break for each of these files.

[Example of a failed echidna run](https://github.com/w3c/lws-protocol/actions/runs/27173121657/job/80216293315)