### PR TITLE
Link set profile

### DIFF
--- a/lws10-core/Operations/create-resource.md
+++ b/lws10-core/Operations/create-resource.md
@@ -54,7 +54,7 @@ In this example, the client is posting to the <a>container</a> `/alice/notes/`. 
 HTTP/1.1 201 Created
 Location: /alice/notes/shoppinglist.txt
 Content-Type: text/plain; charset=UTF-8
-Link: </alice/notes/shoppinglist.txt.meta>; rel="linkset"; type="application/linkset+json; profile="lws-meta""
+Link: </alice/notes/shoppinglist.txt.meta>; rel="linkset"; type="application/linkset+json; profile="lws-meta"
 Link: </alice/notes/>; rel="up"
 Link: <https://www.w3.org/ns/lws#DataResource>; rel="type"
 Content-Length: 0
@@ -76,7 +76,7 @@ Link: <https://www.w3.org/ns/lws#Container>; rel="type"
 ```
 HTTP/1.1 201 Created
 Location: /alice/notes/
-Link: </alice/notes/.meta>; rel="linkset"; type="application/linkset+json; profile="lws-meta""
+Link: </alice/notes/.meta>; rel="linkset"; type="application/linkset+json; profile="lws-meta"
 Link: </alice/>; rel="up"
 Link: <https://www.w3.org/ns/lws#Container>; rel="type"
 Content-Length: 0

--- a/lws10-core/Operations/create-resource.md
+++ b/lws10-core/Operations/create-resource.md
@@ -23,7 +23,7 @@ The **create resource** operation adds a new [served resource](#dfn-served-resou
 
 New resources are created using POST to a target <a>container</a> URI, with the server assigning the final identifier. Clients MAY suggest a name via the `Slug` header. Clients MAY provide initial user-managed metadata for the new resource by including one or more `Link` headers in the POST request, following the syntax of Web Linking in [[RFC8288]]. Server-managed metadata MUST be generated automatically by the server upon creation and MUST NOT be overridden by client-provided links.
 
-On success, the server MUST return the 201 status code with the new URI in the `Location` header. The server MUST include `Link` headers for key server-managed metadata, including a link to the parent <a>container</a> (`rel="up"`), and a link to the created resource's dedicated <a>linkset resource</a> (`rel="linkset"; type="application/linkset+json"`). Additional links SHOULD include `rel="type"` (indicating `https://www.w3.org/ns/lws#Container` or `https://www.w3.org/ns/lws#DataResource`). The body MAY be empty or include a minimal representation of the resource. All metadata creation and linking MUST be atomic with the resource creation to maintain consistency.
+On success, the server MUST return the 201 status code with the new URI in the `Location` header. The server MUST include `Link` headers for key server-managed metadata, including a link to the parent <a>container</a> (`rel="up"`), and a link to the created resource's dedicated <a>linkset resource</a> (`rel="linkset"; type="application/linkset+json"; profile="lws-meta"`). Additional links SHOULD include `rel="type"` (indicating `https://www.w3.org/ns/lws#Container` or `https://www.w3.org/ns/lws#DataResource`). The body MAY be empty or include a minimal representation of the resource. All metadata creation and linking MUST be atomic with the resource creation to maintain consistency.
 
 **POST (to a container URI)** – *Create with server-assigned name:*
 Use POST to add a new resource inside an existing <a>container</a>. The server assigns an identifier to the resource, optionally suggested via the `Slug` header. The server MAY honor the Slug header if it does not conflict with naming rules or existing resources. Clients indicate the type of resource to create as follows:
@@ -54,7 +54,7 @@ In this example, the client is posting to the <a>container</a> `/alice/notes/`. 
 HTTP/1.1 201 Created
 Location: /alice/notes/shoppinglist.txt
 Content-Type: text/plain; charset=UTF-8
-Link: </alice/notes/shoppinglist.txt.meta>; rel="linkset"; type="application/linkset+json"
+Link: </alice/notes/shoppinglist.txt.meta>; rel="linkset"; type="application/linkset+json; profile="lws-meta""
 Link: </alice/notes/>; rel="up"
 Link: <https://www.w3.org/ns/lws#DataResource>; rel="type"
 Content-Length: 0
@@ -76,7 +76,7 @@ Link: <https://www.w3.org/ns/lws#Container>; rel="type"
 ```
 HTTP/1.1 201 Created
 Location: /alice/notes/
-Link: </alice/notes/.meta>; rel="linkset"; type="application/linkset+json"
+Link: </alice/notes/.meta>; rel="linkset"; type="application/linkset+json; profile="lws-meta""
 Link: </alice/>; rel="up"
 Link: <https://www.w3.org/ns/lws#Container>; rel="type"
 Content-Length: 0

--- a/lws10-core/Operations/metadata.md
+++ b/lws10-core/Operations/metadata.md
@@ -12,7 +12,7 @@ Metadata distinguishes between resources and their representations, allowing for
 **The <a>Linkset Resource</a>**
 For each resource in <a>storage</a>, a server MUST make metadata links available as a linkset, according to [[!RFC9264]].
 - Discovery: A resource's linkset is discoverable via a Link header with the relation `rel="linkset"`.
-- Media Type: A <a>linkset resource</a> MUST be available as `application/linkset+json`.
+- Media Type: A <a>linkset resource</a> MUST be available as `application/linkset+json; profile="lws-meta"`. The `lws-meta` profile allows the server to distinguish between linksets as auxiliary resource and linksets as data resource.
 - Integrity: The 'linkset' link MUST point to an <a>LWS resource</a> in the same <a>storage</a>. Updates to the linkset MUST be atomic with associated resource operations to maintain consistency.
 
 **Discovering Metadata**

--- a/lws10-core/Operations/metadata.md
+++ b/lws10-core/Operations/metadata.md
@@ -9,12 +9,11 @@ All metadata in LWS is expressed as a set of typed links originating from a reso
 
 Metadata distinguishes between resources and their representations, allowing for multiple media types where applicable. For <a>data resources</a>, metadata includes representations, each with mediaType and optional sizeInBytes. For <a>containers</a> and <a>data resources</a> we consider the link to its parent <a>container</a> resource to be part of the metadata of the resource.
 
-
 **The <a>Linkset Resource</a>**
-For each resource in <a>storage</a>, a server MUST make metadata links available as a standalone resource according to [[!RFC9264]].
+For each resource in <a>storage</a>, a server MUST make metadata links available as a linkset, according to [[!RFC9264]].
 - Discovery: A resource's linkset is discoverable via a Link header with the relation `rel="linkset"`.
 - Media Type: A <a>linkset resource</a> MUST be available as `application/linkset+json`.
-- Integrity: The 'linkset' link MUST point to a server-managed resource. Updates to the linkset MUST be atomic with associated resource operations to maintain consistency.
+- Integrity: The 'linkset' link MUST point to an <a>LWS resource</a> in the same <a>storage</a>. Updates to the linkset MUST be atomic with associated resource operations to maintain consistency.
 
 **Discovering Metadata**
 Clients discover metadata primarily through Link headers in response to GET or HEAD requests.

--- a/lws10-core/Operations/read-resource.md
+++ b/lws10-core/Operations/read-resource.md
@@ -23,7 +23,7 @@ HTTP/1.1 200 OK
 Content-Type: text/plain; charset=UTF-8
 Content-Length: 34
 ETag: "abc123456"
-Link: </alice/notes/shoppinglist.txt.meta>; rel="linkset"; type="application/linkset+json"
+Link: </alice/notes/shoppinglist.txt.meta>; rel="linkset"; type="application/linkset+json; profile="lws-meta"
 Link: </alice/notes/>; rel="up"
 Link: <https://www.w3.org/ns/lws#DataResource>; rel="type"
 
@@ -52,7 +52,7 @@ Assuming the container exists and the client has access:
 HTTP/1.1 200 OK
 Content-Type: application/lws+json
 ETag: "container-etag-789"
-Link: </alice/notes/.meta>; rel="linkset"; type="application/linkset+json"
+Link: </alice/notes/.meta>; rel="linkset"; type="application/linkset+json; profile="lws-meta"
 Link: </alice/>; rel="up"
 Link: <https://www.w3.org/ns/lws#Container>; rel="type"
 

--- a/lws10-core/Operations/update-resource.md
+++ b/lws10-core/Operations/update-resource.md
@@ -54,9 +54,9 @@ A client first fetches the linkset and receives its ETag.
 ```
 GET /alice/personalinfo.json.meta HTTP/1.1
 Authorization: Bearer <token>
-Accept: application/linkset+json
+Accept: application/linkset+json; profile="lws-meta"
 HTTP/1.1 200 OK
-Content-Type: application/linkset+json
+Content-Type: application/linkset+json; profile="lws-meta"
 ETag: "meta-v1"
 {
   "linkset": [
@@ -71,7 +71,7 @@ The client now wants to add a license. It constructs a new, complete linkset doc
 ```
 PUT /alice/personalinfo.json.meta HTTP/1.1
 Authorization: Bearer <token>
-Content-Type: application/linkset+json
+Content-Type: application/linkset+json; profile="lws-meta"
 If-Match: "meta-v1"
 {
   "linkset": [

--- a/lws10-core/lws-media-type.md
+++ b/lws10-core/lws-media-type.md
@@ -67,7 +67,7 @@ Response (first page):
 HTTP/1.1 200 OK
 Content-Type: application/lws+json
 ETag: "photos-page1-etag"
-Link: </alice/photos/.meta>; rel="linkset"; type="application/linkset+json"
+Link: </alice/photos/.meta>; rel="linkset"; type="application/linkset+json"; profile="lws-meta"
 Link: </alice/>; rel="up"
 Link: </alice/photos/.acl>; rel="acl"
 Link: <https://www.w3.org/ns/lws#Container>; rel="type"
@@ -111,7 +111,7 @@ Response (middle page):
 HTTP/1.1 200 OK
 Content-Type: application/lws+json
 ETag: "photos-page2-etag"
-Link: </alice/photos/.meta>; rel="linkset"; type="application/linkset+json"
+Link: </alice/photos/.meta>; rel="linkset"; type="application/linkset+json"; profile="lws-meta"
 Link: </alice/>; rel="up"
 Link: </alice/photos/.acl>; rel="acl"
 Link: <https://www.w3.org/ns/lws#Container>; rel="type"


### PR DESCRIPTION
As discussed in last week's meeting (2026-06-22), this minor addition to the merged #167 preserves part of the practical advantages of #165: in line with [RFC 9264](https://datatracker.ietf.org/doc/html/rfc9264#name-link-set-profiles) (and the [Content Negotiation by Profile](https://w3c.github.io/dx-connegp/connegp/#altr) draft) this PR adds a `profile="lws-meta"` parameter to `rel=linkset` web links, and the `Content-Type` and `Accept` media types for link sets, so that there can be no confusion between linksets as auxiliary resources and link sets as data resources.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/termontwouter/lws-protocol/pull/180.html" title="Last updated on Jun 29, 2026, 11:46 AM UTC (286c4a9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/180/d6af1a1...termontwouter:286c4a9.html" title="Last updated on Jun 29, 2026, 11:46 AM UTC (286c4a9)">Diff</a>