### PR TITLE
Integrate access request terminology with main terminology section

### DIFF
--- a/lws10-core/index.html
+++ b/lws10-core/index.html
@@ -208,6 +208,17 @@
         This specification defines the following terms:
       </p>
       <ul>
+        <li><dfn>access grant</dfn> &mdash; a data object created by a <a>storage controller</a>, expressing
+        an ability for an <a>agent</a> to perform specific actions on <a>storage</a> resources within certain
+        defined constraints.</li>
+        <li><dfn data-lt="access profiles">access profile</dfn> &mdash; an access profile describes the
+        requirements for expressing a valid access policy. Every access profile is identified
+        with a URI, and a server indicates support for one or more access profiles by
+        referencing them in the <code>conformsTo</code> property of a service object in its
+        <a>storage description</a> resource.</li>
+        <li><dfn>access request</dfn> &mdash; a data object submitted by an <a>agent</a>, expressing a
+        request to perform specific actions on storage resources, including the desired scope
+        and constraints.</li>
         <li><dfn data-lt="agents">agent</dfn> &mdash; a person, social entity, or software identified by a URI.</li>
         <li><dfn data-lt="authentication credentials">authentication credential</dfn> &mdash; a security token that asserts claims about an <a>agent</a> or end-user. This token is secured with a cryptographic proof.
           Examples of authentication credentials include assertions of identity such as OpenID Connect ID Tokens and SAML-based assertions as well as assertions of

--- a/lws10-core/lws-access-requests.html
+++ b/lws10-core/lws-access-requests.html
@@ -19,32 +19,6 @@
   actions, constraints, and assignees. Other profiles could use a different conceptual framework.
 </p>
 
-<div class="issue" title="Integrate with main terminology section">
-<p>
-  This section defines the following terms:
-</p>
-
-<ul>
-  <li>
-    <dfn>Access Request</dfn> &mdash; a data object submitted by an <a>agent</a>, expressing a
-    request to perform specific actions on storage resources, including the desired scope
-    and constraints.
-  </li>
-  <li>
-    <dfn>Access Grant</dfn> &mdash; a data object created by a <a>storage controller</a>, expressing
-    an ability for an <a>agent</a> to perform specific actions on <a>storage</a> resources within certain
-    defined constraints.
-  </li>
-  <li>
-    <dfn data-lt="access profiles">Access Profile</dfn> &mdash; an access profile describes the
-    requirements for expressing a valid access policy. Every access profile is identified
-    with a URI, and a server indicates support for one or more access profiles by
-    referencing them in the <code>conformsTo</code> property of a service object in its
-    <a>storage description</a> resource.
-  </li>
-</ul>
-</div>
-
 <section id="access-discovery">
   <h3>Discovery</h3>
 


### PR DESCRIPTION
This moves the terminology defined in the Access Request section into the main terminology section. This resolves the in-line issue described in the text.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/pull/218.html" title="Last updated on Aug 21, 2026, 3:08 PM UTC (abfa6a9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/218/c3ca694...abfa6a9.html" title="Last updated on Aug 21, 2026, 3:08 PM UTC (abfa6a9)">Diff</a>