### PR TITLE
Replace Activity Streams vocabulary terms with dcterms and LWS equivalents

### DIFF
--- a/lws10-core/Discovery.html
+++ b/lws10-core/Discovery.html
@@ -116,7 +116,7 @@
   "type": "Storage",
   "capability": [{
     "type": "https://feature.example/PatchSupport",
-    "mediaType": {
+    "format": {
       "text/turtle": ["application/sparql-update"],
       "application/n-triples": ["application/sparql-update"],
       "application/linkset+json": ["application/merge-patch+json", "application/json-patch+json"]

--- a/lws10-core/Operations/metadata.md
+++ b/lws10-core/Operations/metadata.md
@@ -7,7 +7,7 @@ All metadata in LWS is expressed as a set of typed links originating from a reso
 - A relation type: A string that defines the nature of the relationship.
 - Optional target attributes: Additional key-value pairs that further describe the link or the target resource.
 
-Metadata distinguishes between resources and their representations, allowing for multiple media types where applicable. For <a>data resources</a>, metadata includes representations, each with mediaType and optional sizeInBytes. For <a>containers</a> and <a>data resources</a> we consider the link to its parent <a>container</a> resource to be part of the metadata of the resource.
+Metadata distinguishes between resources and their representations, allowing for multiple media types where applicable. For <a>data resources</a>, metadata includes representations, each with format and optional sizeInBytes. For <a>containers</a> and <a>data resources</a> we consider the link to its parent <a>container</a> resource to be part of the metadata of the resource.
 
 
 **The <a>Linkset Resource</a>**
@@ -26,7 +26,7 @@ Clients discover metadata primarily through Link headers in response to GET or H
 
 | Category | Description |
 |------------|------------|
-| System Managed | Maintained by the server; Read-Only. Includes `linkset`, `type`, `mediaType`, `size`, `modified`. |
+| System Managed | Maintained by the server; Read-Only. Includes `linkset`, `type`, `format`, `size`, `modified`. |
 | Core Metadata | Managed by the client (subject to server restrictions). Includes `up`, `items`, `title`, `creator`. |
 | User-Defined | Custom vocabularies and indexes created by the user. |
 

--- a/lws10-core/Operations/metadata.md
+++ b/lws10-core/Operations/metadata.md
@@ -7,7 +7,7 @@ All metadata in LWS is expressed as a set of typed links originating from a reso
 - A relation type: A string that defines the nature of the relationship.
 - Optional target attributes: Additional key-value pairs that further describe the link or the target resource.
 
-Metadata distinguishes between resources and their representations, allowing for multiple media types where applicable. For <a>data resources</a>, metadata includes representations, each with format and optional sizeInBytes. For <a>containers</a> and <a>data resources</a> we consider the link to its parent <a>container</a> resource to be part of the metadata of the resource.
+Metadata distinguishes between resources and their representations, allowing for multiple media types where applicable. For <a>data resources</a>, metadata includes representations, each with format and optional sizeInBytes. For <a>containers</a> and <a>data resources</a>, we consider the link to its parent <a>container</a> resource to be part of the metadata of the resource.
 
 
 **The <a>Linkset Resource</a>**

--- a/lws10-core/Operations/read-resource.md
+++ b/lws10-core/Operations/read-resource.md
@@ -65,21 +65,21 @@ Link: <https://www.w3.org/ns/lws#Container>; rel="type"
     {
       "type": "DataResource",
       "id": "/alice/notes/shoppinglist.txt",
-      "mediaType": "text/plain",
+      "format": "text/plain",
       "size": 47,
       "modified": "2025-11-24T12:00:00Z"
     },
     {
       "type": ["DataResource", "http://example.org/customType"],
       "id": "/alice/notes/todo.json",
-      "mediaType": "application/json",
+      "format": "application/json",
       "size": 2048,
       "modified": "2025-11-24T13:00:00Z"
     }
   ]
 }
 ```
-In this example, `/alice/notes/` is a <a>container</a>. The response uses JSON-LD with the LWS context, listing members with required metadata. Each item includes its `type`, `id`, `mediaType`, `size`, and `modified` timestamp as flat properties.
+In this example, `/alice/notes/` is a <a>container</a>. The response uses JSON-LD with the LWS context, listing members with required metadata. Each item includes its `type`, `id`, `format`, `size`, and `modified` timestamp as flat properties.
 
 In all cases, the server MUST include the following metadata in the response headers: an ETag (representing the listing version, which changes on membership modifications), and Link headers with `rel="type"` indicating it is a <a>container</a>, `rel="linkset"` and `rel="up"`.
 

--- a/lws10-core/container-representation.md
+++ b/lws10-core/container-representation.md
@@ -31,7 +31,7 @@ Each entry in the `items` array describes a resource contained in the <a>contain
 
 A contained resource description SHOULD include:
 
-- **`mediaType`**: The media type of the resource (e.g., `"text/plain"`, `"image/jpeg"`). MUST be present for DataResources.
+- **`format`**: The media type of the resource (e.g., `"text/plain"`, `"image/jpeg"`). MUST be present for DataResources.
 - **`size`**: The size of the resource in bytes, expressed as an integer.
 - **`modified`**: The date and time the resource was last modified, expressed as an ISO 8601 date-time string.
 
@@ -49,14 +49,14 @@ The following example shows a <a>container</a> at `/alice/notes/` containing two
     {
       "type": "DataResource",
       "id": "/alice/notes/shoppinglist.txt",
-      "mediaType": "text/plain",
+      "format": "text/plain",
       "size": 47,
       "modified": "2025-11-24T12:00:00Z"
     },
     {
       "type": ["DataResource", "http://example.org/customType"],
       "id": "/alice/notes/todo.json",
-      "mediaType": "application/json",
+      "format": "application/json",
       "size": 2048,
       "modified": "2025-11-24T13:00:00Z"
     }

--- a/lws10-core/lws-access-requests.html
+++ b/lws10-core/lws-access-requests.html
@@ -503,7 +503,7 @@
         <code>client</code> &mdash; representing the client identifier for an HTTP request
       </li>
       <li>
-        <code>mediaType</code> &mdash; representing the media type of the target HTTP
+        <code>format</code> &mdash; representing the media type of the target HTTP
         resource
       </li>
       <li>
@@ -583,12 +583,12 @@
       </pre>
     </section>
 
-    <section id="constraint-mediaType">
-      <h5>Media Type Constraints</h5>
+    <section id="constraint-format">
+      <h5>Format Constraints</h5>
 
       <p>
         The following example uses a <code>leftOperand</code> value of
-        <code>mediaType</code> to restrict
+        <code>format</code> to restrict
         access to resources with specific media types. When the <code>eq</code> operator
         is used, the <code>rightOperand</code> value is a string identifying an
         <a href="https://www.iana.org/assignments/media-types/">IANA media type</a>. When
@@ -597,12 +597,12 @@
         media type matches any of the listed values:
       </p>
 
-      <pre class="example" title="Media type constraint">
+      <pre class="example" title="Format constraint">
 {
   "access": [{
     "constraint": [
       {
-        "leftOperand": "mediaType",
+        "leftOperand": "format",
         "operator": "isAnyOf",
         "rightOperand": ["image/jpeg", "image/png"]
       }

--- a/lws10-core/lws-media-type.md
+++ b/lws10-core/lws-media-type.md
@@ -84,14 +84,14 @@ Link: </alice/photos/?page=2>; rel="next"
     {
       "type": "DataResource",
       "id": "/alice/photos/vacation.jpg",
-      "mediaType": "image/jpeg",
+      "format": "image/jpeg",
       "size": 248392,
       "modified": "2025-11-20T10:30:00Z"
     },
     {
       "type": "DataResource",
       "id": "/alice/photos/portrait.png",
-      "mediaType": "image/png",
+      "format": "image/png",
       "size": 102400,
       "modified": "2025-11-21T14:15:00Z"
     }
@@ -128,7 +128,7 @@ Link: </alice/photos/?page=3>; rel="last"
     {
       "type": "DataResource",
       "id": "/alice/photos/sunset.jpg",
-      "mediaType": "image/jpeg",
+      "format": "image/jpeg",
       "size": 315000,
       "modified": "2025-11-22T09:00:00Z"
     }

--- a/lws10-searchindex/index.html
+++ b/lws10-searchindex/index.html
@@ -395,7 +395,7 @@ Link: &lt;https://example.org/types/index?page=4&gt;; rel="last"
         <p>
           Each item in a <code>ContainerPage</code> result MUST carry at least the matched
           resource's <code>id</code> and its <code>type</code>, mirroring a container member; a
-          server MAY include additional descriptive metadata (such as <code>mediaType</code>,
+          server MAY include additional descriptive metadata (such as <code>format</code>,
           <code>size</code>, or <code>modified</code>) but is not required to.
         </p>
         <p>

--- a/lws10-vocab/vocabulary.yml
+++ b/lws10-vocab/vocabulary.yml
@@ -6,10 +6,10 @@ vocab:
 prefix:
   - id: as
     value: https://www.w3.org/ns/activitystreams#
-  - id: as2
-    value: https://www.w3.org/ns/activitystreams#
   - id: schema
     value: https://schema.org/
+  - id: dc
+    value: http://purl.org/dc/terms/
   - id: dcterms
     value: http://purl.org/dc/terms/
   - id: ldp
@@ -90,17 +90,17 @@ property:
     domain: lws:Container
     comment: The list of resources contained in a container.
 
-  - id: as:totalItems
+  - id: totalItems
     label: total items
     domain: lws:Container
     comment: The total number of items in a container.
 
-  - id: as:mediaType
-    label: media type
+  - id: dc:format
+    label: format
     domain: lws:DataResource
     comment: The media type of a data resource.
 
-  - id: as:updated
+  - id: dc:modified
     label: modified
     domain: lws:DataResource
     range: xsd:dateTime
@@ -197,7 +197,7 @@ property:
     label: access
     comment: The access policies associated with an access request or grant.
 
-  - id: dcterms:conformsTo
+  - id: dc:conformsTo
     label: conforms to
     external: true
     comment: An established standard to which the described resource conforms.
@@ -241,7 +241,7 @@ property:
       - odrl:dateTime
       - client
       - dcterms:type
-      - as2:mediaType
+      - dcterms:format
 
   - id: odrl:operator
     label: operator

--- a/lws10-vocab/vocabulary.yml
+++ b/lws10-vocab/vocabulary.yml
@@ -8,7 +8,7 @@ prefix:
     value: https://www.w3.org/ns/activitystreams#
   - id: schema
     value: https://schema.org/
-  - id: dc
+  - id: dct
     value: http://purl.org/dc/terms/
   - id: dcterms
     value: http://purl.org/dc/terms/
@@ -95,7 +95,7 @@ property:
     domain: lws:Container
     comment: The total number of items in a container.
 
-  - id: dc:format
+  - id: dct:format
     label: format
     domain: lws:DataResource
     comment: The media type of a data resource.

--- a/lws10-vocab/vocabulary.yml
+++ b/lws10-vocab/vocabulary.yml
@@ -100,7 +100,7 @@ property:
     domain: lws:DataResource
     comment: The media type of a data resource.
 
-  - id: dc:modified
+  - id: dcterms:modified
     label: modified
     domain: lws:DataResource
     range: xsd:dateTime
@@ -197,7 +197,7 @@ property:
     label: access
     comment: The access policies associated with an access request or grant.
 
-  - id: dc:conformsTo
+  - id: dcterms:conformsTo
     label: conforms to
     external: true
     comment: An established standard to which the described resource conforms.


### PR DESCRIPTION
Resolves #204 

Container properties currently use terms from the Activity Streams 2.0 vocabulary, which is arguably a poor fit. This changes three terms to use either DC Terms (`dct:format`, `dct:modified`) or, in the case of `totalItems`, an LWS-defined term. Please note, the LWS vocabulary already defines `lws:items`, so defining `lws:totalItems` would make sense.

- `mediaType` (as:mediaType) -> `format` (dct:format)
- `modified` (as:updated) -> `modified` (dct:modified)
- `totalItems` (as:totalItems) -> `totalItems` (lws:totalItems)

From the perspective of the JSON-LD container representation, the `modified` (previously mapped to `as:updated`) and `totalItems` properties appear unchanged, since only the mapping changed. The `mediaType` property is changed to `format`, which involves some changes to the protocol text and examples.

Please note: in the `vocabulary.yml` file, there are two references to the DC Terms namespace: `dct` and `dcterms`. This is intentional as it is necessary for the yml2vocab tool to resolve the short name values as URIs in properties such as `leftOperand`.

The `as` namespace is still present, since we continue to use Activity Stream terms with the notification feature.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/pull/219.html" title="Last updated on Aug 21, 2026, 3:09 PM UTC (a9b0e97)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/219/d807c7a...a9b0e97.html" title="Last updated on Aug 21, 2026, 3:09 PM UTC (a9b0e97)">Diff</a>