### PR TITLE
Rename metadata name for token subject types

### DIFF
--- a/lws10-core/IANA-Considerations.html
+++ b/lws10-core/IANA-Considerations.html
@@ -30,7 +30,7 @@
 
   <ul>
     <li>
-      Metadata Name: token_subject_types_supported
+      Metadata Name: subject_token_types_supported
     </li>
     <li>
       Metadata Description: JSON array containing a list of the OAuth 2.0 "token_subject_type" values that this authorization server supports

--- a/lws10-core/IANA-Considerations.html
+++ b/lws10-core/IANA-Considerations.html
@@ -33,7 +33,7 @@
       Metadata Name: subject_token_types_supported
     </li>
     <li>
-      Metadata Description: JSON array containing a list of the OAuth 2.0 "token_subject_type" values that this authorization server supports
+      Metadata Description: JSON array containing a list of the OAuth 2.0 "subject_token_type" values that this authorization server supports
     </li>
     <li>
       Change Controller: W3C


### PR DESCRIPTION
The property name in the IANA section does not align with the name used throughout the rest of the text.

The correct name is `subject_token_types_supported`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/pull/221.html" title="Last updated on Aug 10, 2026, 1:27 PM UTC (4f4425e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/221/91e1824...4f4425e.html" title="Last updated on Aug 10, 2026, 1:27 PM UTC (4f4425e)">Diff</a>