### PR TITLE
fix: remove Slug header mentions from LWS protocol text

### DIFF
--- a/lws10-core/Operations/create-resource.md
+++ b/lws10-core/Operations/create-resource.md
@@ -21,12 +21,12 @@ The **create resource** operation adds a new [served resource](#dfn-served-resou
 * **Conflict:** A resource with the generated identifier already exists, or there is another state conflict.
 * **Unknown Error:** An unexpected internal error occurred.
 
-New resources are created using POST to a target <a>container</a> URI, with the server assigning the final identifier. Clients MAY suggest a name via the `Slug` header. Clients MAY provide initial user-managed metadata for the new resource by including one or more `Link` headers in the POST request, following the syntax of Web Linking in [[RFC8288]]. Server-managed metadata MUST be generated automatically by the server upon creation and MUST NOT be overridden by client-provided links.
+New resources are created using POST to a target <a>container</a> URI, with the server assigning the final identifier. Clients MAY provide initial user-managed metadata for the new resource by including one or more `Link` headers in the POST request, following the syntax of Web Linking in [[RFC8288]]. Server-managed metadata MUST be generated automatically by the server upon creation and MUST NOT be overridden by client-provided links.
 
 On success, the server MUST return the 201 status code with the new URI in the `Location` header. The server MUST include `Link` headers for key server-managed metadata, including a link to the parent <a>container</a> (`rel="up"`), and a link to the created resource's dedicated <a>linkset resource</a> (`rel="linkset"; type="application/linkset+json"`). Additional links SHOULD include `rel="type"` (indicating `https://www.w3.org/ns/lws#Container` or `https://www.w3.org/ns/lws#DataResource`). The body MAY be empty or include a minimal representation of the resource. All metadata creation and linking MUST be atomic with the resource creation to maintain consistency.
 
 **POST (to a container URI)** – *Create with server-assigned name:*
-Use POST to add a new resource inside an existing <a>container</a>. The server assigns an identifier to the resource, optionally suggested via the `Slug` header. The server MAY honor the Slug header if it does not conflict with naming rules or existing resources. Clients indicate the type of resource to create as follows:
+Use POST to add a new resource inside an existing <a>container</a>. The server assigns the identifier for the resource. Clients indicate the type of resource to create as follows:
 
 - To create a **<a>Container</a>**, the client MUST include a `Link` header with `rel="type"` pointing to the Container type: `Link: <https://www.w3.org/ns/lws#Container>; rel="type"`.
 - To create a **<a>Data resource</a>**, the client includes the resource content in the request body with the appropriate `Content-Type` header.
@@ -38,7 +38,6 @@ Host: example.com
 Authorization: Bearer <token>
 Content-Type: text/plain
 Content-Length: 47
-Slug: shoppinglist.txt
 
 milk
 eggs
@@ -68,7 +67,6 @@ POST /alice/ HTTP/1.1
 Host: example.com
 Authorization: Bearer <token>
 Content-Length: 0
-Slug: notes
 Link: <https://www.w3.org/ns/lws#Container>; rel="type"
 ```
 

--- a/lws10-core/logicalresourceorganization.md
+++ b/lws10-core/logicalresourceorganization.md
@@ -35,7 +35,7 @@ The server MUST maintain <a>containment</a> integrity at all times:
 
 ### Resource Identification
 
-Resources are identified by URIs. The URI of a resource is independent of its position in the <a>containment</a> hierarchy. Servers assign URIs during resource creation and MAY incorporate client hints (e.g., the `Slug` header), but clients SHOULD NOT assume that URI structure reflects containment.
+Resources are identified by URIs. The URI of a resource is independent of its position in the <a>containment</a> hierarchy. Servers assign URIs during resource creation and MAY incorporate client hints, but clients SHOULD NOT assume that URI structure reflects containment.
 
 <a>Containment</a> relationships are expressed through metadata (`rel="up"` links and the `items` property in <a>container</a> representations), not through URI path structure. This separation allows servers flexibility in URI assignment while maintaining a well-defined organizational model.
 


### PR DESCRIPTION
Remove all references to the Slug HTTP header from the core spec prose and HTTP examples, as the protocol does not currently prescribe this mechanism for identity hints or its operational semantics.

Closes #217


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/pull/224.html" title="Last updated on Aug 11, 2026, 9:59 AM UTC (3b761cf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/224/42a8500...3b761cf.html" title="Last updated on Aug 11, 2026, 9:59 AM UTC (3b761cf)">Diff</a>