### PR TITLE
Clarify why OAuth best practices are applicable to lws10-authn-ssi-cid

### DIFF
--- a/lws10-authn-ssi-cid/index.html
+++ b/lws10-authn-ssi-cid/index.html
@@ -212,7 +212,8 @@ signature
       <h2>Security Considerations</h2>
 
       <p>
-        All security considerations described in "Best Current Practice for OAuth 2.0 Security" [[RFC9700]] and "OpenID Connect Core 1.0" Section 16 [[OPENID-CONNECT-CORE]] apply to this specification.
+        As authorization in the Linked Web Storage Protocol [[LWS10-CORE]] is based on the OAuth framework, this authentication suite is applied within the OAuth framework.
+        Therefore, all security considerations described in "Best Current Practice for OAuth 2.0 Security" [[RFC9700]] and "OpenID Connect Core 1.0" Section 16 [[OPENID-CONNECT-CORE]] apply to this specification.
       </p>
     </section>
     <section id="privacy-considerations" class="informative">


### PR DESCRIPTION
As requested in https://github.com/w3c/lws-protocol/issues/139#issuecomment-5144822424, addresses #139.

Added the following first line above the already existing second one:

```html
 <p>
        As authorization in the Linked Web Storage Protocol [[LWS10-CORE]] is based on the OAuth framework, this authentication suite is applied within the OAuth framework.
        Therefore, all security considerations described in "Best Current Practice for OAuth 2.0 Security" [[RFC9700]] and "OpenID Connect Core 1.0" Section 16 [[OPENID-CONNECT-CORE]] apply to this specification.
</p>
```

Did not modify the did:key authn spec as that one will be removed anyway, according to https://github.com/w3c/lws-protocol/issues/141#issuecomment-5144852857.