### PR TITLE
Add subject_identifier_types_supported property to AS Metadata

### DIFF
--- a/lws10-core/Authorization.html
+++ b/lws10-core/Authorization.html
@@ -99,9 +99,11 @@ WWW-Authenticate: Bearer as_uri="https://authorization.example",
         SHOULD advertise the subject tokens that it supports by including this entry in the server metadata document.
       </li>
       <li>
-        <dfn><code>subject_uri_resolvers_supported</code></dfn>
-        OPTIONAL. JSON array containing a list of URI resolver values for subject identifiers that the
-        authorization server supports. An authorization server SHOULD advertise the subject URI resolvers
+        <dfn><code>subject_identifier_types_supported</code></dfn>
+        OPTIONAL. JSON array containing a list of subject identifier types that the authorization server supports.
+        Each value is a URI scheme such as <code>"https"</code> or, for Decentralized Identifiers,
+        a <code>"did:"</code> prefix followed by the DID method name (e.g. <code>"did:web"</code>, <code>"did:key"</code>).
+        An authorization server SHOULD advertise the subject identifier types
         that it supports by including this entry in the server metadata document.
         If omitted, the default value is <code>["https"]</code>.
       </li>
@@ -128,7 +130,7 @@ WWW-Authenticate: Bearer as_uri="https://authorization.example",
     "subject_token_types_supported": [
         "urn:ietf:params:oauth:token-type:jwt",
         "urn:ietf:params:oauth:token-type:id-token"],
-    "subject_uri_resolvers_supported": [
+    "subject_identifier_types_supported": [
         "did:web",
         "did:key",
         "https"]

--- a/lws10-core/Authorization.html
+++ b/lws10-core/Authorization.html
@@ -93,15 +93,15 @@ WWW-Authenticate: Bearer as_uri="https://authorization.example",
 
     <ul>
       <li>
-        <code>subject_token_types_supported</code>
+        <dfn><code>subject_token_types_supported</code></dfn>
         OPTIONAL. JSON array containing a list of valid <code>subject_token_type</code> values
         that can be supplied at the authorization server's token endpoint. An authorization server
         SHOULD advertise the subject tokens that it supports by including this entry in the server metadata document.
       </li>
       <li>
-        <code>subject_uri_schemes_supported</code>
-        OPTIONAL. JSON array containing a list of URI scheme values for subject identifiers that the
-        authorization server supports. An authorization server SHOULD advertise the subject URI schemes
+        <dfn><code>subject_uri_resolvers_supported</code></dfn>
+        OPTIONAL. JSON array containing a list of URI resolver values for subject identifiers that the
+        authorization server supports. An authorization server SHOULD advertise the subject URI resolvers
         that it supports by including this entry in the server metadata document.
         If omitted, the default value is <code>["https"]</code>.
       </li>
@@ -128,7 +128,7 @@ WWW-Authenticate: Bearer as_uri="https://authorization.example",
     "subject_token_types_supported": [
         "urn:ietf:params:oauth:token-type:jwt",
         "urn:ietf:params:oauth:token-type:id-token"],
-    "subject_uri_schemes_supported": [
+    "subject_uri_resolvers_supported": [
         "did:web",
         "did:key",
         "https"]

--- a/lws10-core/Authorization.html
+++ b/lws10-core/Authorization.html
@@ -87,10 +87,25 @@ WWW-Authenticate: Bearer as_uri="https://authorization.example",
     </p>
 
     <p>
-      An authorization server SHOULD advertise the subject tokens that it supports by including a <code>subject_token_types_supported</code>
-      entry in the server metadata document. This entry is a JSON array containing a list of valid <code>subject_token_type</code> values
-      that can be supplied at the authorization server's token endpoint.
+      In addition to the metadata defined in [[!RFC8414]], an LWS authorization server metadata document
+      defines the following parameters:
     </p>
+
+    <ul>
+      <li>
+        <code>subject_token_types_supported</code>
+        OPTIONAL. JSON array containing a list of valid <code>subject_token_type</code> values
+        that can be supplied at the authorization server's token endpoint. An authorization server
+        SHOULD advertise the subject tokens that it supports by including this entry in the server metadata document.
+      </li>
+      <li>
+        <code>subject_uri_schemes_supported</code>
+        OPTIONAL. JSON array containing a list of URI scheme values for subject identifiers that the
+        authorization server supports. An authorization server SHOULD advertise the subject URI schemes
+        that it supports by including this entry in the server metadata document.
+        If omitted, the default value is <code>["https"]</code>.
+      </li>
+    </ul>
 
     <p>
       An example authorization server metadata resource is included below.
@@ -112,7 +127,11 @@ WWW-Authenticate: Bearer as_uri="https://authorization.example",
         "token"],
     "subject_token_types_supported": [
         "urn:ietf:params:oauth:token-type:jwt",
-        "urn:ietf:params:oauth:token-type:id-token"]
+        "urn:ietf:params:oauth:token-type:id-token"],
+    "subject_uri_schemes_supported": [
+        "did:web",
+        "did:key",
+        "https"]
 }
     </pre>
 

--- a/lws10-core/IANA-Considerations.html
+++ b/lws10-core/IANA-Considerations.html
@@ -42,6 +42,21 @@
       Specification Document(s): Section 5 of LWS-Auth
     </li>
   </ul>
+
+  <ul>
+    <li>
+      Metadata Name: subject_uri_schemes_supported
+    </li>
+    <li>
+      Metadata Description: JSON array containing a list of URI scheme values for subject identifiers that this authorization server supports
+    </li>
+    <li>
+      Change Controller: W3C
+    </li>
+    <li>
+      Specification Document(s): Section 5 of LWS-Auth
+    </li>
+  </ul>
 </section>
 
 <section id="iana-media-type-registry">

--- a/lws10-core/IANA-Considerations.html
+++ b/lws10-core/IANA-Considerations.html
@@ -45,10 +45,10 @@
 
   <ul>
     <li>
-      Metadata Name: subject_uri_schemes_supported
+      Metadata Name: subject_uri_resolvers_supported
     </li>
     <li>
-      Metadata Description: JSON array containing a list of URI scheme values for subject identifiers that this authorization server supports
+      Metadata Description: JSON array containing a list of URI resolver values for subject identifiers that this authorization server supports
     </li>
     <li>
       Change Controller: W3C

--- a/lws10-core/IANA-Considerations.html
+++ b/lws10-core/IANA-Considerations.html
@@ -45,10 +45,10 @@
 
   <ul>
     <li>
-      Metadata Name: subject_uri_resolvers_supported
+      Metadata Name: subject_identifier_types_supported
     </li>
     <li>
-      Metadata Description: JSON array containing a list of URI resolver values for subject identifiers that this authorization server supports
+      Metadata Description: JSON array containing a list of subject identifier types that this authorization server supports
     </li>
     <li>
       Change Controller: W3C


### PR DESCRIPTION
Resolves #151 

This defines a new property for the authorization server metadata document: `subject_identifier_types_supported`. (Other, previously considered terms included: `subject_uri_schemes_supported`, `subject_uri_resolvers_supported`).

Inclusion of the new property is set at `SHOULD` level. If omitted, the default value is `["https"]`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/pull/227.html" title="Last updated on Sep 14, 2026, 1:15 PM UTC (afd3e40)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/227/602ca19...afd3e40.html" title="Last updated on Sep 14, 2026, 1:15 PM UTC (afd3e40)">Diff</a>