### PR TITLE
Define how resources move between containers

### DIFF
--- a/lws10-core/Discovery.html
+++ b/lws10-core/Discovery.html
@@ -83,6 +83,57 @@
     <p>
       A <a>storage description</a> may contain descriptions of additional capabilities supported by the <a>storage</a>.
     </p>
+
+    <p>
+      A <a>storage</a> that allows clients to modify link relations that it would otherwise manage itself,
+      as described in <a href="#metadata"></a>, MUST describe a capability whose <code>type</code> equals
+      <code>MetadataUpdate</code>. Clients MUST NOT assume that such a link relation is modifiable in the
+      absence of this capability. The following properties are defined for a <code>MetadataUpdate</code>
+      capability:
+    </p>
+
+    <ul>
+      <li>
+        <strong>`modifiable`</strong> - the <code>modifiable</code> property is REQUIRED. Its value MUST be a set of
+        link relation types that clients are allowed to modify on the <a>linkset resource</a> of an
+        <a>LWS resource</a>. Listing <code>up</code> indicates that the <a>storage</a> supports moving resources
+        between <a>containers</a>, as described in <a href="#moving-resources"></a>.
+      </li>
+      <li>
+        <strong>`appliesTo`</strong> - the <code>appliesTo</code> property is OPTIONAL. If present, its value MUST be a
+        set of strings naming the types of <a>LWS resource</a> the capability applies to, such as
+        <code>DataResource</code> or <code>Container</code>. If the property is absent, the capability applies
+        to <a>data resources</a> only.
+      </li>
+      <li>
+        <strong>`preservesIdentifier`</strong> - the <code>preservesIdentifier</code> property is OPTIONAL.
+        If present, its value MUST be a boolean indicating whether the <a>storage</a> preserves the identifier
+        of a resource whose <a>containment</a> metadata is modified. If the property is absent, clients
+        MUST NOT assume that identifiers are preserved, and MUST rely on the response to the update
+        to determine the identifier of the resource.
+      </li>
+    </ul>
+
+    <pre id="example-storage-description-move" class="example" title="Storage description resource advertising that clients may move resources between containers">
+{
+  "@context": [
+    "https://www.w3.org/ns/cid/v1",
+    "https://www.w3.org/ns/lws/v1"
+  ],
+  "id": "https://storage.example/",
+  "type": "Storage",
+  "capability": [{
+    "type": "MetadataUpdate",
+    "modifiable": ["up"],
+    "appliesTo": ["DataResource", "Container"],
+    "preservesIdentifier": true
+  }],
+  "service": [{
+    "type": "StorageRoot",
+    "serviceEndpoint": "https://storage.example/root/"
+  }]
+}
+    </pre>
   </section>
 
   <section id="storage-description-services">

--- a/lws10-core/Notifications.html
+++ b/lws10-core/Notifications.html
@@ -149,11 +149,11 @@
       </li>
       <li>
         <code>target</code> &mdash; a URI identifying the container into which the
-        resource was added. Used with <code>Create</code> activities.
+        resource was added. Used with <code>Create</code> and <code>Move</code> activities.
       </li>
       <li>
         <code>origin</code> &mdash; a URI identifying the container from which the
-        resource was removed. Used with <code>Delete</code> activities.
+        resource was removed. Used with <code>Delete</code> and <code>Move</code> activities.
       </li>
     </ul>
   </section>
@@ -177,6 +177,20 @@
       <li>
         <code>Delete</code> &mdash; a resource was removed. The <code>origin</code> field
         indicates the container from which the resource was removed.
+      </li>
+    </ul>
+
+    <p>
+      A server that allows clients to move resources between containers, as described in
+      <a href="#moving-resources"></a>, MUST support the following activity type:
+    </p>
+
+    <ul>
+      <li>
+        <code>Move</code> &mdash; a resource was moved from one container to another. The
+        <code>origin</code> field indicates the container from which the resource was removed,
+        and the <code>target</code> field indicates the container into which it was added. The
+        <code>object</code> field describes the resource as it exists after the move.
       </li>
     </ul>
 

--- a/lws10-core/Operations/metadata.md
+++ b/lws10-core/Operations/metadata.md
@@ -49,6 +49,6 @@ Metadata is managed by interacting with the resource's associated <a>linkset res
 
 - Replacement (PUT): If advertised in the Allow header, a client MAY replace the entire linkset. If the server does not support PUT, it MUST reject the request with 405 Method Not Allowed.
 
-- Restrictions: Servers MAY restrict modifications to specific links (like `up` or `items`) to maintain system integrity.
+- Restrictions: Servers MAY restrict modifications to specific links (like `up` or `items`) to maintain system integrity. A server that lifts such a restriction MUST advertise the affected link relations in its <a>storage description</a>, as described in [](#storage-description-capabilities), and MUST preserve the links a client is not permitted to modify when applying a patch. Allowing clients to modify the `up` link moves the resource between <a>containers</a>; the resulting requirements are defined in [](#moving-resources).
 
 - Lifecycle: Metadata lifecycles are tied to the described resource; deleting a resource MUST result in the automatic removal of its associated <a>linkset resource</a> metadata.

--- a/lws10-core/Operations/moving-resources.md
+++ b/lws10-core/Operations/moving-resources.md
@@ -1,0 +1,124 @@
+This specification does not define a dedicated operation for moving a <a>served resource</a> from one <a>container</a> to another. A move is instead expressed as an update of the <a>containment</a> metadata of the resource: a client changes the `up` link in the resource's <a>linkset resource</a> to point at the destination <a>container</a>, using the [update resource](#update-resource) operation. The server derives the effective move from that change.
+
+<div class="note">
+A move cannot be reduced to a <a href="#create-resource">create resource</a> operation followed by a <a href="#delete-resource">delete resource</a> operation. Servers assign resource identifiers, so a client that recreates the content in another <a>container</a> cannot preserve the identifier of the original resource, and every link pointing at that identifier is broken as a result. The two requests are also not atomic: an observer may see the resource in both <a>containers</a>, or in neither. Expressing the move as a change to the <a>containment</a> metadata avoids both problems, because the identity of the resource and its content are untouched by the change.
+</div>
+
+**Server support:**
+The `up` link is managed by the server, and servers are not required to allow clients to modify it, as described in [](#metadata). A server that allows clients to modify the `up` link of a resource, and thereby to move resources between <a>containers</a>, MUST advertise this in its <a>storage description</a>, as described in [](#storage-description-capabilities), and MUST implement the requirements in this section. A server that does not allow it MUST reject the request with 403 Forbidden, and MUST NOT advertise `up` as a modifiable link relation.
+
+**Requesting a move:**
+A client moves a resource by applying a partial update to the resource's <a>linkset resource</a>, replacing the target of the `up` link with the identifier of the destination <a>container</a>. As required by [](#metadata), servers MUST support `application/merge-patch+json` [[RFC7386]] for this update, and clients MUST include an `If-Match` header field carrying the current ETag of the <a>linkset resource</a>.
+
+The destination MUST be an existing <a>container</a> within the same <a>storage</a>. Servers MUST reject a patch whose `up` link does not identify such a <a>container</a> with 409 Conflict, and a patch that leaves the resource without an `up` link with 409 Conflict, as every non-root resource is reachable from the <a>storage root</a>.
+
+<p class="issue" data-number="148">
+JSON Merge Patch replaces arrays as a whole, so a patch that carries the `linkset` array replaces every link context in the <a>linkset resource</a>, not only the `up` link. This specification requires servers to preserve the links a client is not permitted to modify, but a client that also maintains user-defined links has to restate them in every patch. The Working Group may want to consider a link-scoped patch format for <a>linkset resources</a>, along the lines of the `application/linkset-patch+json` media type sketched in <a href="https://github.com/w3c/lws-protocol/pull/83">w3c/lws-protocol#83</a>.
+</p>
+
+**Effect on <a>containment</a>:**
+On a successful update, the server MUST atomically remove the resource from the `items` list of its former parent <a>container</a> and add it to the `items` list of the destination <a>container</a>. The `totalItems` count of both <a>containers</a> SHOULD be updated accordingly, and the ETag of both <a>containers</a> MUST be updated to reflect the change.
+
+The content of the moved resource and its user-defined metadata are unaffected by the move. Servers MUST preserve the links in the <a>linkset resource</a> that the client is not permitted to modify, including server-managed links such as `linkset` and `type`. <a>Auxiliary resources</a> whose lifetime is bound to the moved resource remain bound to it after the move.
+
+Servers MUST reject an update that would violate the <a>containment</a> integrity requirements in [](#logical-resource-organization) with 409 Conflict. In particular, a <a>container</a> MUST NOT be moved into itself or into one of its own descendants, as this would introduce a cycle in the <a>containment</a> hierarchy.
+
+**Identity of the moved resource:**
+The URI of a resource is independent of its position in the <a>containment</a> hierarchy, as described in [](#logical-resource-organization). Servers SHOULD therefore preserve the identifier of a moved resource, so that existing links to it remain valid, and SHOULD indicate whether they do so with the `preservesIdentifier` property of the advertised capability.
+
+A server that cannot preserve the identifier MUST respond with 200 OK and a representation of the updated <a>linkset resource</a> whose `anchor` is the new identifier of the resource, and MUST include a `Content-Location` header field carrying the new identifier of the <a>linkset resource</a> itself. Such a server SHOULD respond to subsequent requests on the previous identifiers of the resource and of its <a>auxiliary resources</a> with 301 Moved Permanently, including a `Location` header field pointing at the new identifier.
+
+**Moving <a>containers</a>:**
+Servers MAY support modifying the `up` link of a <a>container</a>, in which case the descendants of that <a>container</a> move with it and their identifiers are subject to the same requirements as those of the moved <a>container</a>. A server that supports moving resources but not <a>containers</a> MUST reject the request with 403 Forbidden, and MUST restrict the advertised capability to <a>data resources</a>.
+
+**Authorization:**
+A server MUST NOT apply a change to an `up` link unless the requesting <a>agent</a> is authorized both to perform the [delete resource](#delete-resource) operation on the resource being moved and to perform the [create resource](#create-resource) operation in the destination <a>container</a>. When a <a>container</a> is moved, this requirement applies to every resource in the moved subtree.
+
+<div class="note">
+Access to a resource is frequently governed by policies that are expressed in terms of the resource's position in the <a>containment</a> hierarchy. Moving a resource may therefore change who can access it, in either direction, without any policy being edited. Servers SHOULD make this consequence visible to <a>storage controllers</a>, and clients SHOULD warn <a>agents</a> before moving resources between <a>containers</a> that are governed by different policies. See <a href="#security-moving-resources"></a> and <a href="#privacy-moving-resources"></a>.
+</div>
+
+**Example (move a data resource to another container):**
+```
+PATCH /alice/notes/shoppinglist.txt.meta HTTP/1.1
+Host: example.com
+Authorization: Bearer <token>
+Content-Type: application/merge-patch+json
+If-Match: "meta-v3"
+
+{
+  "linkset": [{
+    "anchor": "/alice/notes/shoppinglist.txt",
+    "up": [{ "href": "/alice/archive/" }]
+  }]
+}
+```
+Assuming the client is authorized, `/alice/archive/` exists, and the server preserves resource identifiers, the server removes the resource from the `items` list of `/alice/notes/`, adds it to the `items` list of `/alice/archive/`, and updates the <a>linkset resource</a>, atomically:
+```
+HTTP/1.1 204 No Content
+ETag: "meta-v4"
+Link: </alice/archive/>; rel="up"
+```
+The resource remains available at `/alice/notes/shoppinglist.txt`, and is now a member of `/alice/archive/`.
+
+**Example (move where the server assigns a new identifier):**
+```
+PATCH /alice/notes/shoppinglist.txt.meta HTTP/1.1
+Host: example.com
+Authorization: Bearer <token>
+Content-Type: application/merge-patch+json
+If-Match: "meta-v3"
+
+{
+  "linkset": [{
+    "anchor": "/alice/notes/shoppinglist.txt",
+    "up": [{ "href": "/alice/archive/" }]
+  }]
+}
+```
+A server whose identifiers reflect the <a>containment</a> hierarchy cannot preserve the identifier and reports the resulting identifiers in the updated <a>linkset resource</a>:
+```
+HTTP/1.1 200 OK
+Content-Type: application/linkset+json
+Content-Location: /alice/archive/shoppinglist.txt.meta
+ETag: "meta-v4"
+
+{
+  "linkset": [{
+    "anchor": "/alice/archive/shoppinglist.txt",
+    "up": [{ "href": "/alice/archive/" }],
+    "linkset": [{ "href": "/alice/archive/shoppinglist.txt.meta",
+                  "type": "application/linkset+json" }]
+  }]
+}
+```
+
+**Example (move a container into one of its own descendants):**
+```
+PATCH /alice/notes/.meta HTTP/1.1
+Host: example.com
+Authorization: Bearer <token>
+Content-Type: application/merge-patch+json
+If-Match: "meta-v7"
+
+{
+  "linkset": [{
+    "anchor": "/alice/notes/",
+    "up": [{ "href": "/alice/notes/2026/" }]
+  }]
+}
+```
+The server refuses the update, as it would introduce a cycle in the <a>containment</a> hierarchy:
+```
+HTTP/1.1 409 Conflict
+Content-Type: application/problem+json
+
+{
+  "title": "Cannot move a container into one of its own descendants",
+  "status": 409,
+  "detail": "/alice/notes/2026/ is a descendant of /alice/notes/"
+}
+```
+
+**Notifications:**
+A server that supports moving resources and emits notifications SHOULD describe a successful move with a single `Move` activity, as described in [](#activity-types), rather than with a separate `Delete` and `Create` activity.

--- a/lws10-core/Privacy-Considerations.html
+++ b/lws10-core/Privacy-Considerations.html
@@ -63,3 +63,27 @@
   </ul>
 </section>
 
+<section id="privacy-moving-resources" class="informative">
+  <h4>Moving Resources Between Containers</h4>
+
+  <ul>
+    <li>
+      <strong>Unintended Exposure</strong>: An <a>agent</a> moving a resource may not realize
+      that the destination <a>container</a> is governed by more permissive policies than the
+      source. Clients SHOULD surface the difference in applicable policies before changing the
+      <code>up</code> link of a resource.
+    </li>
+    <li>
+      <strong>Retained Identifiers</strong>: Where a server preserves the identifier of a moved
+      resource, that identifier keeps disclosing the <a>container</a> in which the resource was
+      originally created, if the identifier was derived from it. Servers that treat identifiers
+      as opaque avoid this disclosure.
+    </li>
+    <li>
+      <strong>Redirects</strong>: A 301 Moved Permanently response left behind at a previous
+      identifier discloses the new position of a resource to <a>agents</a> that may not be
+      authorized to access it. Servers SHOULD apply the same access control to such responses
+      as to the moved resource itself, and MAY respond with 404 Not Found instead.
+    </li>
+  </ul>
+</section>

--- a/lws10-core/Security-Considerations.html
+++ b/lws10-core/Security-Considerations.html
@@ -73,3 +73,38 @@
   </ul>
 </section>
 
+<section id="security-moving-resources" class="informative">
+  <h4>Moving Resources Between Containers</h4>
+
+  <ul>
+    <li>
+      <strong>Change of Applicable Policy</strong>: Access to a resource is frequently governed
+      by policies expressed in terms of the resource's position in the <a>containment</a>
+      hierarchy. Changing the <code>up</code> link of a resource may therefore widen or narrow
+      the set of <a>agents</a> that can access it, without any policy being edited and without
+      the content of the resource changing. Servers SHOULD make this consequence visible to the
+      <a>storage controller</a>, and clients SHOULD warn <a>agents</a> before moving a resource
+      into a <a>container</a> that is governed by different policies.
+    </li>
+    <li>
+      <strong>Privilege Combination</strong>: Moving a resource combines the effects of a delete
+      in the source <a>container</a> and a create in the destination <a>container</a>. Servers
+      MUST evaluate both authorizations, as required by <a href="#moving-resources"></a>;
+      evaluating only the authorization to update the metadata of the resource would allow an
+      <a>agent</a> to place resources in <a>containers</a> they cannot write to, or to remove
+      resources from <a>containers</a> they cannot delete from.
+    </li>
+    <li>
+      <strong>Moving Containers</strong>: Moving a <a>container</a> moves its descendants, which
+      may include resources the requesting <a>agent</a> is not aware of. Servers that support
+      moving <a>containers</a> MUST authorize the change for every resource in the moved subtree,
+      and MUST NOT partially apply a move that fails authorization for part of the subtree.
+    </li>
+    <li>
+      <strong>Relaxing Server-Managed Metadata</strong>: Advertising a link relation as modifiable
+      makes metadata that servers otherwise maintain themselves writable by clients. Servers
+      SHOULD advertise the narrowest set of modifiable link relations that their deployment
+      requires, and MUST continue to preserve the links a client is not permitted to modify.
+    </li>
+  </ul>
+</section>

--- a/lws10-core/index.html
+++ b/lws10-core/index.html
@@ -326,6 +326,11 @@
         <h2>Delete resource</h2>
 		<div data-include="Operations/delete-resource.md" data-include-format="markdown" data-include-replace="true"></div>
       </section>
+
+      <section id="moving-resources">
+        <h2>Moving resources between containers</h2>
+		<div data-include="Operations/moving-resources.md" data-include-format="markdown" data-include-replace="true"></div>
+      </section>
 	  <div data-include="Operations/rest-table.md" data-include-format="markdown" data-include-replace="true"></div>
     </section>
 

--- a/lws10-core/logicalresourceorganization.md
+++ b/lws10-core/logicalresourceorganization.md
@@ -22,7 +22,7 @@ The <a>containment</a> relationship between a resource and its parent <a>contain
 Link: </alice/notes/>; rel="up"
 ```
 
-A <a>container</a>'s members are listed in its representation using the `items` property. The server manages this list; clients cannot modify it directly. Membership changes occur as a side effect of resource creation and deletion.
+A <a>container</a>'s members are listed in its representation using the `items` property. The server manages this list; clients cannot modify it directly. Membership changes occur as a side effect of resource creation and deletion, and, on servers that allow the `up` link of a resource to be modified, of moving a resource between <a>containers</a> as described in [](#moving-resources).
 
 ### Containment Integrity
 
@@ -30,6 +30,7 @@ The server MUST maintain <a>containment</a> integrity at all times:
 
 - **Creation**: When a new resource is created in a <a>container</a>, the server MUST atomically add the resource to the <a>container</a>'s `items` list.
 - **Deletion**: When a resource is deleted, the server MUST atomically remove it from its parent <a>container</a>'s `items` list. Deleting a <a>container</a> requires the <a>container</a> to be empty, unless recursive deletion is explicitly requested.
+- **Move**: When the `up` link of a resource is changed, the server MUST atomically remove the resource from the `items` list of its former parent <a>container</a> and add it to the `items` list of the destination <a>container</a>. Support for changing the `up` link is OPTIONAL, and the resulting requirements are defined in [](#moving-resources).
 - **No orphans**: Every non-root resource MUST be reachable from the <a>storage root</a> through the <a>containment</a> hierarchy.
 - **No cycles**: A <a>container</a> MUST NOT directly or indirectly contain itself.
 

--- a/lws10-vocab/vocabulary.yml
+++ b/lws10-vocab/vocabulary.yml
@@ -84,6 +84,11 @@ class:
     label: Access Request Service
     comment: A service endpoint for managing access requests.
 
+  - id: MetadataUpdate
+    label: Metadata Update
+    comment: A capability indicating which link relations, otherwise managed by the storage, clients are allowed to modify on a linkset resource.
+    defined_by: https://www.w3.org/TR/lws-core/
+
 property:
   - id: items
     label: items
@@ -116,6 +121,25 @@ property:
     label: capability
     domain: lws:Storage
     comment: A capability supported by the storage.
+
+  - id: modifiable
+    label: modifiable
+    domain: lws:MetadataUpdate
+    comment: A link relation type that clients are allowed to modify on the linkset resource of an LWS resource.
+    defined_by: https://www.w3.org/TR/lws-core/
+
+  - id: appliesTo
+    label: applies to
+    domain: lws:MetadataUpdate
+    comment: The types of LWS resource a capability applies to.
+    defined_by: https://www.w3.org/TR/lws-core/
+
+  - id: preservesIdentifier
+    label: preserves identifier
+    domain: lws:MetadataUpdate
+    range: xsd:boolean
+    comment: Whether a storage preserves the identifier of a resource whose containment metadata is modified.
+    defined_by: https://www.w3.org/TR/lws-core/
 
   - id: PreferLinkRelations
     label: Prefer Link Relations
@@ -161,6 +185,10 @@ property:
   - id: as:Delete
     label: Delete
     comment: An activity representing the deletion of a resource.
+
+  - id: as:Move
+    label: Move
+    comment: An activity representing the move of a resource from one container to another.
 
   - id: as:object
     label: object


### PR DESCRIPTION
Closes #148.

Extracts the ability to move a resource between containers — part of the multiple containment proposal in #83 that the group did not keep — into its own section, following the discussion in the [2026-08-24 minutes](https://www.w3.org/2026/08/24-lws-minutes.html).

## What is proposed

No new operation. A move is expressed as an **update of the containment metadata of the resource**: the client changes the `up` link in the resource's linkset with the existing *update resource* operation, and the server derives the effective move from that change. New section `lws10-core/Operations/moving-resources.md`, included after *delete resource*.

```http
PATCH /alice/notes/shoppinglist.txt.meta HTTP/1.1
Content-Type: application/merge-patch+json
If-Match: "meta-v3"

{
  "linkset": [{
    "anchor": "/alice/notes/shoppinglist.txt",
    "up": [{ "href": "/alice/archive/" }]
  }]
}

HTTP/1.1 204 No Content
ETag: "meta-v4"
Link: </alice/archive/>; rel="up"
```

- **What is advertised is metadata updatability, not a move feature.** The `up` link is server-managed, and the specification already says servers MAY restrict modifications to it. A storage that lifts that restriction describes a `MetadataUpdate` capability listing the link relations clients may modify; listing `up` is what makes moving possible. `appliesTo` says which resource types it covers (data resources only when absent), `preservesIdentifier` says whether identifiers survive a move. A server that does not allow the change rejects the patch with 403 Forbidden.
- **Containment integrity.** The server atomically removes the resource from the `items` list of the former parent and adds it to the destination's, updating `totalItems` and both ETags. Moving a container into itself or one of its own descendants is rejected with 409 Conflict, as is a patch that leaves a resource with no `up` link.
- **Identifiers.** Because a resource's URI is independent of its position in the hierarchy, servers SHOULD preserve it — which is exactly what create + delete cannot do. A server that cannot responds 200 OK with the updated linkset, whose `anchor` carries the new identifier, plus `Content-Location`, and SHOULD leave 301s behind.
- **Authorization.** Permitted only when the agent may delete the source resource *and* create in the destination container; for a container, every resource in the subtree.
- **Containers are left to implementers.** Servers MAY support changing the `up` link of a container, in which case the subtree follows; those that do not reject the patch and restrict the advertised capability to data resources.
- **Concurrency comes for free.** The existing linkset rules already require `If-Match`, so a move is conditional by construction: 412 on mismatch, 428 when absent.
- **Notifications.** A single Activity Streams `Move` activity with `origin` and `target`, instead of a `Delete`/`Create` pair.
- **Security and privacy considerations** on how a move silently changes the policies applicable to a resource, on the combination of delete and create privileges, on recursive moves, on relaxing server-managed metadata, and on what a left-behind 301 discloses.

`lws10-vocab` gains the `MetadataUpdate` class, the `modifiable`, `appliesTo` and `preservesIdentifier` properties, and `as:Move`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/pull/237.html" title="Last updated on Aug 29, 2026, 11:41 AM UTC (530c5f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-protocol/237/602ca19...530c5f0.html" title="Last updated on Aug 29, 2026, 11:41 AM UTC (530c5f0)">Diff</a>